### PR TITLE
Create base class for tiles buttons

### DIFF
--- a/lib/models/tile_title_bar_info.dart
+++ b/lib/models/tile_title_bar_info.dart
@@ -1,0 +1,5 @@
+class TileTitleBarInfo {
+  String title;
+
+  TileTitleBarInfo(this.title);
+}

--- a/lib/pages/configurations_page/configurations_page.dart
+++ b/lib/pages/configurations_page/configurations_page.dart
@@ -44,19 +44,27 @@ class _ConfigurationsPageState extends XboxPageState<ConfigurationsPage> {
           PaneItem(
               icon: const SizedBox(),
               title: const Text("General"),
-              body: const GenralConfigurationSection()),
+              body: GenralConfigurationSection(
+                currentScope: elementFocusScope,
+              )),
           PaneItem(
               icon: const SizedBox(),
               title: const Text("Profile"),
-              body: const ProfileConfigurationSection()),
+              body: ProfileConfigurationSection(
+                currentScope: elementFocusScope,
+              )),
           PaneItem(
               icon: const SizedBox(),
               title: const Text("Cloud gaming"),
-              body: CloudGamingConfigurationSection()),
+              body: CloudGamingConfigurationSection(
+                currentScope: elementFocusScope,
+              )),
           PaneItem(
               icon: const SizedBox(),
               title: const Text("About"),
-              body: const AboutConfigurationSection())
+              body: AboutConfigurationSection(
+                currentScope: elementFocusScope,
+              ))
         ]);
   }
 }

--- a/lib/pages/configurations_page/sections/about_configuration_section.dart
+++ b/lib/pages/configurations_page/sections/about_configuration_section.dart
@@ -3,7 +3,8 @@ import 'package:xbox_launcher/shared/app_text_style.dart';
 import 'package:xbox_launcher/shared/widgets/navigations/navigation_section_stateless.dart';
 
 class AboutConfigurationSection extends NavigationSectionStateless {
-  const AboutConfigurationSection({Key? key}) : super("About", key: key);
+  const AboutConfigurationSection({super.key, required super.currentScope})
+      : super("About");
 
   @override
   List<Widget>? titleActions(BuildContext context) => null;

--- a/lib/pages/configurations_page/sections/cloud_gaming_configuration_section.dart
+++ b/lib/pages/configurations_page/sections/cloud_gaming_configuration_section.dart
@@ -11,7 +11,8 @@ class CloudGamingConfigurationSection extends NavigationSectionStateless {
   final TextEditingController jsonUrlTextController = TextEditingController();
   final TextEditingController controllerTest = TextEditingController();
 
-  CloudGamingConfigurationSection({Key? key}) : super("Cloud Gaming", key: key);
+  CloudGamingConfigurationSection({super.key, required super.currentScope})
+      : super("Cloud Gaming");
 
   @override
   List<Widget>? titleActions(BuildContext context) => null;

--- a/lib/pages/configurations_page/sections/general_configurations_section.dart
+++ b/lib/pages/configurations_page/sections/general_configurations_section.dart
@@ -5,7 +5,8 @@ import 'package:xbox_launcher/shared/widgets/buttons/icon_text_button.dart';
 import 'package:xbox_launcher/shared/widgets/navigations/navigation_section_stateless.dart';
 
 class GenralConfigurationSection extends NavigationSectionStateless {
-  const GenralConfigurationSection({Key? key}) : super("General", key: key);
+  const GenralConfigurationSection({super.key, required super.currentScope})
+      : super("General");
 
   @override
   List<Widget>? titleActions(BuildContext context) => null;

--- a/lib/pages/configurations_page/sections/profile_configuration_section.dart
+++ b/lib/pages/configurations_page/sections/profile_configuration_section.dart
@@ -10,7 +10,8 @@ import 'package:xbox_launcher/shared/widgets/dialogs/system_dialog.dart';
 import 'package:xbox_launcher/shared/widgets/navigations/navigation_section_stateless.dart';
 
 class ProfileConfigurationSection extends NavigationSectionStateless {
-  const ProfileConfigurationSection({Key? key}) : super("Profile", key: key);
+  const ProfileConfigurationSection({super.key, required super.currentScope})
+      : super("Profile");
 
   Future _removeProfileFlow(ProfileModel toRemove, BuildContext context) {
     return SystemDialog(

--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -62,11 +62,11 @@ class HomePage extends XboxPageStateless {
                         return value.lastApps.isEmpty
                             ? const WellcomingMessage()
                             : AppsTileRow(
-                                tiles: value.lastApps,
-                                customGenerateOption: TileGeneratorOption(
-                                    context: context,
-                                    focusScope: elementFocusScope),
-                              );
+                              tiles: value.lastApps,
+                              customGenerateOption: TileGeneratorOption(
+                                  context: context,
+                                  focusScope: elementFocusScope),
+                            );
                       },
                     ),
                     const SizedBox(height: 30),

--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -11,6 +11,7 @@ import 'package:xbox_launcher/shared/widgets/placeholder_messages/wellcoming_mes
 import 'package:xbox_launcher/shared/widgets/buttons/system_banner_button.dart';
 import 'package:xbox_launcher/shared/widgets/profile_avatar/profile_info.dart';
 import 'package:xbox_launcher/shared/enums/tile_size.dart';
+import 'package:xbox_launcher/shared/widgets/tiles/app_tiles_row.dart';
 import 'package:xbox_launcher/shared/widgets/tiles/tile_row.dart';
 import 'package:xbox_launcher/shared/widgets/utils/generators/models/tile_generator_option.dart';
 import 'package:xbox_launcher/shared/widgets/utils/generators/widget_gen.dart';
@@ -57,12 +58,12 @@ class HomePage extends XboxPageStateless {
                     builder: (_, value, __) {
                       return value.lastApps.isEmpty
                           ? const WellcomingMessage()
-                          : TileRow(
-                              tiles: WidgetGen.generateByModel(
-                                  value.lastApps,
-                                  TileGeneratorOption(
-                                      [TileSize.BIG, TileSize.MEDIUM],
-                                      context: context)));
+                          : AppsTileRow(
+                              tiles: value.lastApps,
+                              customGenerateOption: TileGeneratorOption(
+                                  context: context,
+                                  focusScope: elementFocusScope),
+                            );
                     },
                   )),
               const Spacer(),

--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -31,12 +31,12 @@ class HomePage extends XboxPageStateless {
             height: double.infinity,
             child: Background()),
         Padding(
-          padding: const EdgeInsets.all(50),
+          padding: const EdgeInsets.only(left: 50, top: 50, right: 50),
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
               Flexible(
-                flex: 0,
+                flex: 1,
                 child: Row(
                   children: [
                     const Flexible(child: ProfileInfo()),
@@ -52,32 +52,34 @@ class HomePage extends XboxPageStateless {
                 ),
               ),
               const Spacer(),
-              Flexible(
-                  flex: 10,
-                  child: Consumer<ProfileProvider>(
-                    builder: (_, value, __) {
-                      return value.lastApps.isEmpty
-                          ? const WellcomingMessage()
-                          : AppsTileRow(
-                              tiles: value.lastApps,
-                              customGenerateOption: TileGeneratorOption(
-                                  context: context,
-                                  focusScope: elementFocusScope),
-                            );
-                    },
-                  )),
-              const Spacer(),
-              Flexible(
-                flex: 5,
-                child: Row(
+              Expanded(
+                flex: 0,
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
-                    Flexible(
-                      child: SystemBannerButton(
-                        "My games",
-                        onClick: () => Navigator.pushNamed(
-                            context, AppRoutes.myLibraryRoute),
-                        icon: FluentIcons.library,
-                      ),
+                    Consumer<ProfileProvider>(
+                      builder: (_, value, __) {
+                        return value.lastApps.isEmpty
+                            ? const WellcomingMessage()
+                            : AppsTileRow(
+                                tiles: value.lastApps,
+                                customGenerateOption: TileGeneratorOption(
+                                    context: context,
+                                    focusScope: elementFocusScope),
+                              );
+                      },
+                    ),
+                    const SizedBox(height: 30),
+                    Row(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        SystemBannerButton(
+                          "My games",
+                          onClick: () => Navigator.pushNamed(
+                              context, AppRoutes.myLibraryRoute),
+                          icon: FluentIcons.library,
+                        ),
+                      ],
                     ),
                   ],
                 ),

--- a/lib/pages/my_library_page/my_library_page.dart
+++ b/lib/pages/my_library_page/my_library_page.dart
@@ -117,7 +117,9 @@ class _MyGamesPageState extends XboxPageState<MyLibraryPage> {
       PaneItem(
           icon: const Icon(FluentIcons.favorite_list),
           title: const Text("Group"),
-          body: const AppsGroupSection()),
+          body: AppsGroupSection(
+            currentScope: elementFocusScope,
+          )),
       PaneItem(
           icon: const Icon(FluentIcons.library),
           title: const Text("Full library"),

--- a/lib/pages/my_library_page/sections/apps_group_section.dart
+++ b/lib/pages/my_library_page/sections/apps_group_section.dart
@@ -2,11 +2,13 @@ import 'package:fluent_ui/fluent_ui.dart' hide TextButton;
 import 'package:provider/provider.dart';
 import 'package:xbox_launcher/providers/profile_provider.dart';
 import 'package:xbox_launcher/shared/widgets/group_viwer/group_viwer.dart';
+import 'package:xbox_launcher/shared/widgets/group_viwer/profile_groups_viwer.dart';
 import 'package:xbox_launcher/shared/widgets/navigations/navigation_section_stateless.dart';
 import 'package:xbox_launcher/shared/widgets/placeholder_messages/no_groups_message.dart';
 
 class AppsGroupSection extends NavigationSectionStateless {
-  const AppsGroupSection({super.key}) : super("Groups");
+  const AppsGroupSection({super.key, required super.currentScope})
+      : super("Groups");
 
   @override
   List<Widget>? titleActions(BuildContext context) => null;
@@ -17,15 +19,8 @@ class AppsGroupSection extends NavigationSectionStateless {
       Consumer<ProfileProvider>(builder: (_, value, __) {
         if (value.appsGroups.isEmpty) return const NoGroupsMessage();
 
-        return Expanded(
-          flex: 20,
-          child: ListView(
-            children: value.appsGroups
-                .map((group) => Container(
-                    margin: const EdgeInsets.only(bottom: 20.0),
-                    child: GroupViwer(group)))
-                .toList(),
-          ),
+        return ProfileGroupsViewer(
+          elementFocusScope: currentScope,
         );
       })
     ];

--- a/lib/pages/my_library_page/sections/full_library_section.dart
+++ b/lib/pages/my_library_page/sections/full_library_section.dart
@@ -7,6 +7,7 @@ import 'package:xbox_launcher/providers/profile_provider.dart';
 import 'package:xbox_launcher/shared/enums/tile_size.dart';
 import 'package:xbox_launcher/shared/widgets/buttons/search_button.dart';
 import 'package:xbox_launcher/shared/widgets/navigations/navigation_section_stateless.dart';
+import 'package:xbox_launcher/shared/widgets/tiles/apps_tile_grid.dart';
 import 'package:xbox_launcher/shared/widgets/tiles/tile_grid.dart';
 import 'package:xbox_launcher/shared/widgets/utils/generators/models/tile_generator_option.dart';
 import 'package:xbox_launcher/shared/widgets/utils/generators/widget_gen.dart';
@@ -19,7 +20,8 @@ class FullLibrarySection extends NavigationSectionStateless {
 
   void Function(void Function())? _reloadTilesGrid;
 
-  FullLibrarySection({super.key, super.currentScope}) : super("Full library");
+  FullLibrarySection({super.key, required super.currentScope})
+      : super("Full library");
 
   Future<List<GameModel>?> _loadXCloudGames(BuildContext context) async {
     ProfileProvider profileProvider = context.read<ProfileProvider>();
@@ -89,12 +91,10 @@ class FullLibrarySection extends NavigationSectionStateless {
                     case ConnectionState.waiting:
                       return const ProgressRing();
                     default:
-                      return TileGrid.tileSize(
-                        tileSize: tileSize,
-                        tiles: WidgetGen.generateByModel(
-                            searchResult ?? library,
-                            TileGeneratorOption([tileSize],
-                                focusScope: currentScope, context: context)),
+                      return AppsTilesGrid(
+                        apps: searchResult ?? library,
+                        customGenerationOption: TileGeneratorOption(
+                            focusScope: currentScope, context: context),
                         scrollDirection: Axis.vertical,
                       );
                   }

--- a/lib/pages/my_library_page/sections/full_library_section.dart
+++ b/lib/pages/my_library_page/sections/full_library_section.dart
@@ -93,6 +93,8 @@ class FullLibrarySection extends NavigationSectionStateless {
                     default:
                       return AppsTilesGrid(
                         apps: searchResult ?? library,
+                        mainAxisSpacing: 10,
+                        crossAxisSpacing: 10,
                         customGenerationOption: TileGeneratorOption(
                             focusScope: currentScope, context: context),
                         scrollDirection: Axis.vertical,

--- a/lib/pages/my_library_page/sections/manage_section.dart
+++ b/lib/pages/my_library_page/sections/manage_section.dart
@@ -12,7 +12,8 @@ import 'package:xbox_launcher/shared/widgets/infos_provider/volume_info/volume_i
 import 'package:xbox_launcher/shared/widgets/navigations/navigation_section_stateless.dart';
 
 class ManageSection extends NavigationSectionStateless {
-  const ManageSection({super.key, super.currentScope}) : super("Manage");
+  const ManageSection({super.key, required super.currentScope})
+      : super("Manage");
 
   Future<List<DiskInfo>?> getDiskInfos() {
     SystemInfoGetter infoGetter = SystemInfoGetter();
@@ -33,7 +34,7 @@ class ManageSection extends NavigationSectionStateless {
             IconTextButton(
                 title: "Tile size",
                 icon: FluentIcons.size_legacy,
-                focusNode: currentScope?.createFocusNode(),
+                focusNode: currentScope.createFocusNode(),
                 onPressed: () {
                   ContextMenu("Tiles sizes", contextItems: [
                     ContextMenuItem("Small", onPressed: () {

--- a/lib/pages/my_library_page/sections/my_apps_section.dart
+++ b/lib/pages/my_library_page/sections/my_apps_section.dart
@@ -1,32 +1,24 @@
 import 'package:fluent_ui/fluent_ui.dart';
-import 'package:provider/provider.dart';
 import 'package:xbox_launcher/controllers/system_app_controller.dart';
-import 'package:xbox_launcher/providers/profile_provider.dart';
-import 'package:xbox_launcher/shared/enums/tile_size.dart';
 import 'package:xbox_launcher/shared/widgets/navigations/navigation_section_stateless.dart';
-import 'package:xbox_launcher/shared/widgets/tiles/tile_grid.dart';
+import 'package:xbox_launcher/shared/widgets/tiles/apps_tile_grid.dart';
 import 'package:xbox_launcher/shared/widgets/utils/generators/models/tile_generator_option.dart';
-import 'package:xbox_launcher/shared/widgets/utils/generators/widget_gen.dart';
 
 class MyAppsSection extends NavigationSectionStateless {
-  const MyAppsSection({super.key, super.currentScope}) : super("Apps");
+  const MyAppsSection({super.key, required super.currentScope}) : super("Apps");
 
   @override
   List<Widget>? titleActions(BuildContext context) => null;
 
   @override
   List<Widget> columnItems(BuildContext context) {
-    final TileSize tileSize = context.read<ProfileProvider>().myLibraryTileSize;
-
     return [
       Expanded(
           flex: 7,
-          child: TileGrid.tileSize(
-            tileSize: tileSize,
-            tiles: WidgetGen.generateByModel(
-                SystemAppController.systemApps,
-                TileGeneratorOption([tileSize],
-                    focusScope: currentScope, context: context)),
+          child: AppsTilesGrid(
+            apps: SystemAppController.systemApps,
+            customGenerationOption:
+                TileGeneratorOption(focusScope: currentScope, context: context),
             scrollDirection: Axis.vertical,
           ))
     ];

--- a/lib/pages/my_library_page/sections/my_apps_section.dart
+++ b/lib/pages/my_library_page/sections/my_apps_section.dart
@@ -16,6 +16,8 @@ class MyAppsSection extends NavigationSectionStateless {
       Expanded(
           flex: 7,
           child: AppsTilesGrid(
+            crossAxisSpacing: 10,
+            mainAxisSpacing: 10,
             apps: SystemAppController.systemApps,
             customGenerationOption:
                 TileGeneratorOption(focusScope: currentScope, context: context),

--- a/lib/pages/my_library_page/sections/my_games_section.dart
+++ b/lib/pages/my_library_page/sections/my_games_section.dart
@@ -13,6 +13,7 @@ import 'package:xbox_launcher/shared/widgets/listbox/listbox.dart';
 import 'package:xbox_launcher/shared/enums/sort_options.dart';
 import 'package:xbox_launcher/shared/widgets/navigations/navigation_section_stateless.dart';
 import 'package:xbox_launcher/shared/widgets/placeholder_messages/xcloud_file_unavailable_message.dart';
+import 'package:xbox_launcher/shared/widgets/tiles/apps_tile_grid.dart';
 import 'package:xbox_launcher/shared/widgets/tiles/tile_grid.dart';
 import 'package:xbox_launcher/shared/widgets/utils/generators/models/tile_generator_option.dart';
 import 'package:xbox_launcher/shared/widgets/utils/generators/widget_gen.dart';
@@ -34,7 +35,7 @@ class MyGamesSection extends NavigationSectionStateless {
   late ChipsRow chipsRow;
   List<ChipBase>? chipsList;
 
-  MyGamesSection({super.key, super.currentScope}) : super("Games");
+  MyGamesSection({super.key, required super.currentScope}) : super("Games");
 
   Future<bool> readXCloudGames(BuildContext context) async {
     ProfileProvider profileProvider = context.read<ProfileProvider>();
@@ -87,7 +88,7 @@ class MyGamesSection extends NavigationSectionStateless {
       tempChipsList.add(TextChip(
         gameGenre,
         value: gameGenre,
-        focusNode: currentScope?.createFocusNode(),
+        focusNode: currentScope.createFocusNode(),
       ));
     }
 
@@ -208,13 +209,11 @@ class MyGamesSection extends NavigationSectionStateless {
                                 const Spacer(),
                                 Expanded(
                                   flex: 20,
-                                  child: TileGrid.tileSize(
-                                    tileSize: tileSize,
-                                    tiles: WidgetGen.generateByModel(
-                                        gamesSearchResult ?? gamesList,
-                                        TileGeneratorOption([tileSize],
-                                            focusScope: currentScope,
-                                            context: context)),
+                                  child: AppsTilesGrid(
+                                    apps: gamesSearchResult ?? gamesList,
+                                    customGenerationOption: TileGeneratorOption(
+                                        focusScope: currentScope,
+                                        context: context),
                                     scrollDirection: Axis.vertical,
                                   ),
                                 )

--- a/lib/pages/my_library_page/sections/my_games_section.dart
+++ b/lib/pages/my_library_page/sections/my_games_section.dart
@@ -211,6 +211,8 @@ class MyGamesSection extends NavigationSectionStateless {
                                   flex: 20,
                                   child: AppsTilesGrid(
                                     apps: gamesSearchResult ?? gamesList,
+                                    mainAxisSpacing: 10,
+                                    crossAxisSpacing: 10,
                                     customGenerationOption: TileGeneratorOption(
                                         focusScope: currentScope,
                                         context: context),

--- a/lib/pages/personalization_configuration_page.dart
+++ b/lib/pages/personalization_configuration_page.dart
@@ -41,7 +41,7 @@ class PersonalizationConfigurationPage extends ConfigurationMenu {
 
   void setMainColor(BuildContext context) {
     MenuDialogOverlay("Colors",
-        content: TileGrid.build(
+        content: GridView.builder(
           gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
               crossAxisSpacing: 10, mainAxisSpacing: 10, crossAxisCount: 2),
           itemCount: AppColors.COLORS_LIST.length - 1,
@@ -63,7 +63,7 @@ class PersonalizationConfigurationPage extends ConfigurationMenu {
 
   void setBackgroundColor(BuildContext context) {
     MenuDialogOverlay("Background color",
-        content: TileGrid.build(
+        content: GridView.builder(
           gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
               crossAxisSpacing: 10, mainAxisSpacing: 10, crossAxisCount: 2),
           itemCount: AppColors.COLORS_LIST.length - 1,

--- a/lib/pages/personalization_configuration_page.dart
+++ b/lib/pages/personalization_configuration_page.dart
@@ -47,7 +47,6 @@ class PersonalizationConfigurationPage extends ConfigurationMenu {
           itemCount: AppColors.COLORS_LIST.length - 1,
           itemBuilder: (context, index) {
             return ButtonTile(
-              "",
               tileSize: TileSize.MEDIUM,
               color: AppColors.COLORS_LIST[index],
               onPressed: (context) {
@@ -69,7 +68,6 @@ class PersonalizationConfigurationPage extends ConfigurationMenu {
           itemCount: AppColors.COLORS_LIST.length - 1,
           itemBuilder: (context, index) {
             return ButtonTile(
-              "",
               tileSize: TileSize.MEDIUM,
               color: AppColors.COLORS_LIST[index],
               onPressed: (context) {

--- a/lib/shared/widgets/group_viwer/group_viwer.dart
+++ b/lib/shared/widgets/group_viwer/group_viwer.dart
@@ -3,6 +3,7 @@ import 'package:xbox_launcher/models/apps_group.dart';
 import 'package:xbox_launcher/shared/enums/tile_size.dart';
 import 'package:xbox_launcher/shared/widgets/buttons/text_outlined_button.dart';
 import 'package:xbox_launcher/shared/widgets/dialogs/context_menu/context_menu_group.dart';
+import 'package:xbox_launcher/shared/widgets/tiles/apps_tile_grid.dart';
 import 'package:xbox_launcher/shared/widgets/tiles/tile_grid.dart';
 import 'package:xbox_launcher/shared/widgets/utils/generators/models/tile_generator_option.dart';
 import 'package:xbox_launcher/shared/widgets/utils/generators/widget_gen.dart';
@@ -10,13 +11,13 @@ import 'package:xbox_launcher/shared/widgets/utils/generators/widget_gen.dart';
 class GroupViwer extends StatelessWidget {
   final AppsGroup group;
   final SliverGridDelegate? appsGridDelegate;
-  final TileGeneratorOption? tileGeneratorOption;
+  final TileGeneratorOption tileGeneratorOption;
   final bool buttonEnable;
 
   const GroupViwer(this.group,
       {super.key,
       this.appsGridDelegate,
-      this.tileGeneratorOption,
+      required this.tileGeneratorOption,
       this.buttonEnable = true});
 
   @override
@@ -31,17 +32,11 @@ class GroupViwer extends StatelessWidget {
               buttonEnable ? ContextMenuGroup(group).show(context) : null,
         ),
         const SizedBox(height: 5.0),
-        TileGrid.count(
-          gridDelegate: appsGridDelegate ??
-              const SliverGridDelegateWithFixedCrossAxisCount(
-                crossAxisCount: 6,
-                crossAxisSpacing: 10,
-                mainAxisSpacing: 10,
-              ),
-          tiles: WidgetGen.generateByModel(
-              group.apps,
-              tileGeneratorOption ??
-                  TileGeneratorOption([TileSize.MEDIUM], context: context)),
+        AppsTilesGrid(
+          apps: group.apps,
+          crossAxisSpacing: 10,
+          mainAxisSpacing: 10,
+          customGenerationOption: tileGeneratorOption,
         )
       ],
     );

--- a/lib/shared/widgets/group_viwer/profile_groups_viwer.dart
+++ b/lib/shared/widgets/group_viwer/profile_groups_viwer.dart
@@ -1,0 +1,34 @@
+import 'package:fluent_ui/fluent_ui.dart';
+import 'package:provider/provider.dart';
+import 'package:xbox_launcher/providers/profile_provider.dart';
+import 'package:xbox_launcher/shared/widgets/focus/element_focus_scope.dart';
+import 'package:xbox_launcher/shared/widgets/group_viwer/group_viwer.dart';
+import 'package:xbox_launcher/shared/widgets/utils/generators/models/tile_generator_option.dart';
+
+class ProfileGroupsViewer extends StatelessWidget {
+  final ElementFocusScope elementFocusScope;
+
+  const ProfileGroupsViewer({super.key, required this.elementFocusScope});
+
+  @override
+  Widget build(BuildContext context) {
+    return Expanded(
+      flex: 20,
+      child: Consumer<ProfileProvider>(
+        builder: (context, value, __) => ListView(
+          children: value.appsGroups
+              .map((group) => Container(
+                  margin: const EdgeInsets.only(bottom: 20.0),
+                  child: GroupViwer(
+                    group,
+                    tileGeneratorOption: TileGeneratorOption(
+                      focusScope: elementFocusScope,
+                      context: context,
+                    ),
+                  )))
+              .toList(),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/shared/widgets/navigations/navigation_section_stateless.dart
+++ b/lib/shared/widgets/navigations/navigation_section_stateless.dart
@@ -9,10 +9,10 @@ abstract class NavigationSectionStateless extends StatelessWidget
   @override
   final String sectionName;
   @override
-  final ElementFocusScope? currentScope;
+  final ElementFocusScope currentScope;
 
   const NavigationSectionStateless(this.sectionName,
-      {Key? key, this.currentScope})
+      {Key? key, required this.currentScope})
       : super(key: key);
 
   @override

--- a/lib/shared/widgets/tiles/app_tiles_row.dart
+++ b/lib/shared/widgets/tiles/app_tiles_row.dart
@@ -1,0 +1,74 @@
+import 'package:fluent_ui/fluent_ui.dart';
+import 'package:xbox_launcher/models/app_models/game_model.dart';
+import 'package:xbox_launcher/models/app_models/system_app_model.dart';
+import 'package:xbox_launcher/shared/enums/app_type.dart';
+import 'package:xbox_launcher/shared/enums/tile_size.dart';
+import 'package:xbox_launcher/models/app_models/app_model.dart';
+import 'package:xbox_launcher/shared/widgets/focus/element_focus_node.dart';
+import 'package:xbox_launcher/shared/widgets/tiles/game_button_tile.dart';
+import 'package:xbox_launcher/shared/widgets/tiles/models/tile_widget.dart';
+import 'package:xbox_launcher/shared/widgets/tiles/system_app_tile.dart';
+import 'package:xbox_launcher/shared/widgets/tiles/utils/tiles_generator.dart';
+import 'package:xbox_launcher/shared/widgets/utils/generators/models/tile_generator_option.dart';
+
+class AppsTileRow extends StatelessWidget implements TileGenerator {
+  final List<AppModel> tiles;
+  final TileGeneratorOption customGenerateOption;
+
+  const AppsTileRow(
+      {super.key, required this.tiles, required this.customGenerateOption});
+
+  @override
+  List<TileWidget> generateByModel(List<AppModel> appModels, TileSize tilesSize,
+      TileGeneratorOption option) {
+    List<TileWidget> tiles = List.empty(growable: true);
+
+    for (AppModel model in appModels) {
+      TileWidget tile;
+      ElementFocusNode? focusNode = option.focusScope?.createFocusNode();
+
+      switch (model.appType) {
+        case AppType.GAME:
+          tile = GameButtonTile(
+            model as GameModel,
+            tileSize: tilesSize,
+            focusNode: focusNode,
+          );
+          break;
+        case AppType.SYSTEM_APP:
+          tile = SystemAppButtonTile(
+            model as SystemAppModel,
+            tileSize: tilesSize,
+            context: option.context,
+            focusNode: focusNode,
+          );
+          break;
+        default:
+          throw UnimplementedError(
+              model.runtimeType.toString() + " not implemented yet.");
+      }
+      tiles.add(tile);
+    }
+
+    return tiles;
+  }
+
+  List<Widget> wrapInFlexibles(List<TileWidget> tiles) {
+    List<Widget> spacedRow = List.empty(growable: true);
+
+    for (TileWidget tile in tiles) {
+      spacedRow.add(Flexible(flex: spacedRow.length > 1 ? 30 : 0, child: tile));
+      spacedRow.add(const Spacer());
+    }
+
+    return spacedRow;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: wrapInFlexibles(
+          generateByModel(tiles, TileSize.MEDIUM, customGenerateOption)),
+    );
+  }
+}

--- a/lib/shared/widgets/tiles/app_tiles_row.dart
+++ b/lib/shared/widgets/tiles/app_tiles_row.dart
@@ -12,10 +12,10 @@ import 'package:xbox_launcher/shared/widgets/tiles/utils/tiles_generator.dart';
 import 'package:xbox_launcher/shared/widgets/utils/generators/models/tile_generator_option.dart';
 
 class AppsTileRow extends StatelessWidget implements TileGenerator {
-  final List<AppModel> tiles;
+  List<AppModel> tiles;
   final TileGeneratorOption customGenerateOption;
 
-  const AppsTileRow(
+  AppsTileRow(
       {super.key, required this.tiles, required this.customGenerateOption});
 
   @override

--- a/lib/shared/widgets/tiles/apps_tile_grid.dart
+++ b/lib/shared/widgets/tiles/apps_tile_grid.dart
@@ -1,0 +1,93 @@
+import 'package:fluent_ui/fluent_ui.dart';
+import 'package:provider/provider.dart';
+import 'package:xbox_launcher/models/app_models/app_model.dart';
+import 'package:xbox_launcher/models/app_models/game_model.dart';
+import 'package:xbox_launcher/models/app_models/system_app_model.dart';
+import 'package:xbox_launcher/providers/profile_provider.dart';
+import 'package:xbox_launcher/shared/enums/app_type.dart';
+import 'package:xbox_launcher/shared/enums/tile_size.dart';
+import 'package:xbox_launcher/shared/widgets/focus/element_focus_node.dart';
+import 'package:xbox_launcher/shared/widgets/tiles/game_button_tile.dart';
+import 'package:xbox_launcher/shared/widgets/tiles/models/tile_widget.dart';
+import 'package:xbox_launcher/shared/widgets/tiles/system_app_tile.dart';
+import 'package:xbox_launcher/shared/widgets/tiles/utils/tiles_generator.dart';
+import 'package:xbox_launcher/shared/widgets/utils/generators/models/tile_generator_option.dart';
+
+class AppsTilesGrid extends StatelessWidget implements TileGenerator {
+  final List<AppModel> apps;
+  final Axis scrollDirection;
+  final TileGeneratorOption customGenerationOption;
+  final double? crossAxisSpacing;
+  final double? mainAxisSpacing;
+
+  const AppsTilesGrid(
+      {super.key,
+      required this.apps,
+      this.crossAxisSpacing,
+      this.mainAxisSpacing,
+      this.scrollDirection = Axis.vertical,
+      required this.customGenerationOption});
+
+  int _crossAxisCount(TileSize tileSize) {
+    switch (tileSize) {
+      case TileSize.SMALL:
+        return 8;
+      case TileSize.BIG:
+        return 4;
+      case TileSize.LENGHTY:
+      case TileSize.MEDIUM:
+      default:
+        return 6;
+    }
+  }
+
+  @override
+  List<TileWidget> generateByModel(
+      List<AppModel> appModels, TileSize tilesSize, TileGeneratorOption option,
+      {List<ElementFocusNode>? appsFocusNodes}) {
+    List<TileWidget> tiles = List.empty(growable: true);
+
+    for (AppModel model in appModels) {
+      TileWidget tile;
+      ElementFocusNode? focusNode = option.focusScope?.createFocusNode();
+
+      switch (model.appType) {
+        case AppType.GAME:
+          tile = GameButtonTile(
+            model as GameModel,
+            tileSize: tilesSize,
+            focusNode: focusNode,
+          );
+          break;
+        case AppType.SYSTEM_APP:
+          tile = SystemAppButtonTile(
+            model as SystemAppModel,
+            tileSize: tilesSize,
+            context: option.context,
+            focusNode: focusNode,
+          );
+          break;
+        default:
+          throw UnimplementedError(
+              model.runtimeType.toString() + " not implemented yet.");
+      }
+      tiles.add(tile);
+    }
+
+    return tiles;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final appsTileSize = context.read<ProfileProvider>().myLibraryTileSize;
+
+    return GridView.count(
+      crossAxisCount: _crossAxisCount(appsTileSize),
+      crossAxisSpacing: crossAxisSpacing ?? 0.0,
+      mainAxisSpacing: mainAxisSpacing ?? 0.0,
+      shrinkWrap: true,
+      scrollDirection: scrollDirection,
+      children: generateByModel(apps, appsTileSize, customGenerationOption),
+    );
+  }
+}

--- a/lib/shared/widgets/tiles/apps_tile_row.dart
+++ b/lib/shared/widgets/tiles/apps_tile_row.dart
@@ -1,0 +1,74 @@
+import 'package:fluent_ui/fluent_ui.dart';
+import 'package:xbox_launcher/models/app_models/game_model.dart';
+import 'package:xbox_launcher/models/app_models/system_app_model.dart';
+import 'package:xbox_launcher/shared/enums/app_type.dart';
+import 'package:xbox_launcher/shared/enums/tile_size.dart';
+import 'package:xbox_launcher/models/app_models/app_model.dart';
+import 'package:xbox_launcher/shared/widgets/focus/element_focus_node.dart';
+import 'package:xbox_launcher/shared/widgets/tiles/game_button_tile.dart';
+import 'package:xbox_launcher/shared/widgets/tiles/models/tile_widget.dart';
+import 'package:xbox_launcher/shared/widgets/tiles/system_app_tile.dart';
+import 'package:xbox_launcher/shared/widgets/tiles/utils/tiles_generator.dart';
+import 'package:xbox_launcher/shared/widgets/utils/generators/models/tile_generator_option.dart';
+
+class AppsTileRow extends StatelessWidget implements TileGenerator {
+  final List<AppModel> tiles;
+  final TileGeneratorOption customGenerateOption;
+
+  const AppsTileRow(
+      {super.key, required this.tiles, required this.customGenerateOption});
+
+  @override
+  List<TileWidget> generateByModel(List<AppModel> appModels, TileSize tilesSize,
+      TileGeneratorOption option) {
+    List<TileWidget> tiles = List.empty(growable: true);
+
+    for (AppModel model in appModels) {
+      TileWidget tile;
+      ElementFocusNode? focusNode = option.focusScope?.createFocusNode();
+
+      switch (model.appType) {
+        case AppType.GAME:
+          tile = GameButtonTile(
+            model as GameModel,
+            tileSize: tilesSize,
+            focusNode: focusNode,
+          );
+          break;
+        case AppType.SYSTEM_APP:
+          tile = SystemAppButtonTile(
+            model as SystemAppModel,
+            tileSize: tilesSize,
+            context: option.context,
+            focusNode: focusNode,
+          );
+          break;
+        default:
+          throw UnimplementedError(
+              model.runtimeType.toString() + " not implemented yet.");
+      }
+      tiles.add(tile);
+    }
+
+    return tiles;
+  }
+
+  List<Widget> wrapInFlexibles(List<TileWidget> tiles) {
+    List<Widget> spacedRow = List.empty(growable: true);
+
+    for (TileWidget tile in tiles) {
+      spacedRow.add(Flexible(flex: spacedRow.length > 1 ? 30 : 0, child: tile));
+      spacedRow.add(const Spacer());
+    }
+
+    return spacedRow;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: wrapInFlexibles(
+          generateByModel(tiles, TileSize.MEDIUM, customGenerateOption)),
+    );
+  }
+}

--- a/lib/shared/widgets/tiles/button_tile.dart
+++ b/lib/shared/widgets/tiles/button_tile.dart
@@ -2,128 +2,62 @@ import 'package:fluent_ui/fluent_ui.dart';
 import 'package:xbox_launcher/models/app_badge_info.dart';
 import 'package:xbox_launcher/shared/enums/tile_size.dart';
 import 'package:xbox_launcher/shared/widgets/focus/element_focus_node.dart';
-import 'package:xbox_launcher/shared/widgets/tiles/tile_badges.dart';
-import 'package:xbox_launcher/shared/widgets/tiles/tile_base_stateful.dart';
+import 'package:xbox_launcher/shared/widgets/focus/focable_element.dart';
+import 'package:xbox_launcher/shared/widgets/tiles/models/covered_tile.dart';
+import 'package:xbox_launcher/shared/widgets/tiles/models/tile_widget.dart';
 import 'package:xbox_launcher/shared/widgets/tiles/tile_cover.dart';
-import 'package:xbox_launcher/shared/widgets/tiles/tile_title_bar.dart';
 
-class ButtonTile extends TileBaseStateful {
-  final String title;
+class ButtonTile extends TileWidget implements CoveredTile, FocableElement {
   final bool interactive;
-  final AppBadgeInfo? appBadgeInfo;
-  final IconData? icon;
-  final Widget? customCover;
+  @override
+  AppBadgeInfo? appBadgeInfo;
+  @override
+  IconData? icon;
+  @override
+  Widget? customCover;
   final ImageProvider? image;
-  final void Function(BuildContext)? onPressed;
 
-  @override
-  final Color? color;
-  @override
-  late final double height;
-  @override
-  late final double width;
   @override
   Object? elementValue;
+
   @override
   ElementFocusNode? focusNode;
+
+  late bool getFocused;
 
   late final TileSize _tileSize;
   TileSize get tileSize => _tileSize;
 
-  @override
-  State<StatefulWidget> createState() => _ButtonTileState();
-
-  ButtonTile(this.title,
-      {Key? key,
+  ButtonTile(String title,
+      {super.key,
       required TileSize tileSize,
       this.interactive = false,
       this.appBadgeInfo,
-      this.color,
-      this.onPressed,
+      super.color,
+      super.onPressed,
       this.icon,
       this.customCover,
       this.image,
       this.elementValue,
       this.focusNode})
-      : super(key: key) {
-    _tileSize = tileSize;
-    switch (tileSize) {
-      case TileSize.SMALL:
-        width = 100;
-        height = 100;
-        break;
-      case TileSize.MEDIUM:
-        width = 150;
-        height = 150;
-        break;
-      case TileSize.BIG:
-        width = 300;
-        height = 300;
-        break;
-      case TileSize.LENGHTY:
-        width = 200;
-        height = 100;
-        break;
-    }
-
-    focusNode?.setFocucableElement(this);
-  }
-}
-
-class _ButtonTileState extends TileBaseStatefulState<ButtonTile> {
-  late bool getFocused;
-  TileTitleBar? _titleBar;
-  TileBadges? _tileBadges;
-  late final FocusNode focusNode;
-
-  @override
-  void initState() {
-    super.initState();
-
-    focusNode = widget.focusNode ?? FocusNode();
-
-    if (widget.appBadgeInfo != null) {
-      _tileBadges = TileBadges(widget.appBadgeInfo!);
-    }
-
-    if (!widget.interactive) return;
-    focusNode.addListener(() {
-      if (!mounted) return;
-      setState(() {
-        _titleBar = focusNode.hasFocus ? TileTitleBar(widget.title) : null;
-        _tileBadges = !focusNode.hasFocus && widget.appBadgeInfo != null
-            ? TileBadges(widget.appBadgeInfo!)
-            : null;
-      });
-    });
-  }
+      : super(tileSize: tileSize);
 
   @override
   Widget virtualBuild(BuildContext context) {
     return Button(
-      focusNode: focusNode,
       style: ButtonStyle(
           backgroundColor: ButtonState.all(Colors.transparent),
           elevation: ButtonState.all(0),
           padding: ButtonState.all(EdgeInsets.zero)),
-      onPressed: () => widget.onPressed!(context),
+      onPressed: () => onPressed?.call(context),
       child: Stack(
         children: [
           TileCover(
-            customCover: widget.customCover,
-            icon: widget.icon,
-            image: widget.image,
-            color: widget.color,
+            customCover: customCover,
+            icon: icon,
+            image: image,
+            color: color,
           ),
-          Align(
-              alignment: Alignment.bottomLeft,
-              child: Padding(
-                  padding:
-                      const EdgeInsets.only(left: 3.0, right: 3.0, bottom: 3.0),
-                  child: _tileBadges ?? const SizedBox())),
-          Align(
-              alignment: Alignment.bottomLeft,
-              child: _titleBar ?? const SizedBox())
         ],
       ),
     );

--- a/lib/shared/widgets/tiles/button_tile.dart
+++ b/lib/shared/widgets/tiles/button_tile.dart
@@ -1,16 +1,22 @@
+// ignore_for_file: curly_braces_in_flow_control_structures
 import 'package:fluent_ui/fluent_ui.dart';
 import 'package:xbox_launcher/models/app_badge_info.dart';
+import 'package:xbox_launcher/models/tile_title_bar_info.dart';
 import 'package:xbox_launcher/shared/enums/tile_size.dart';
 import 'package:xbox_launcher/shared/widgets/focus/element_focus_node.dart';
 import 'package:xbox_launcher/shared/widgets/focus/focable_element.dart';
 import 'package:xbox_launcher/shared/widgets/tiles/models/covered_tile.dart';
 import 'package:xbox_launcher/shared/widgets/tiles/models/tile_widget.dart';
+import 'package:xbox_launcher/shared/widgets/tiles/tile_badges.dart';
 import 'package:xbox_launcher/shared/widgets/tiles/tile_cover.dart';
+import 'package:xbox_launcher/shared/widgets/tiles/tile_title_bar.dart';
 
 class ButtonTile extends TileWidget implements CoveredTile, FocableElement {
   final bool interactive;
   @override
   AppBadgeInfo? appBadgeInfo;
+  @override
+  TileTitleBarInfo? tileTitleBarInfo;
   @override
   IconData? icon;
   @override
@@ -25,11 +31,12 @@ class ButtonTile extends TileWidget implements CoveredTile, FocableElement {
 
   late bool getFocused;
 
-  ButtonTile(String title,
+  ButtonTile(
       {super.key,
       required TileSize tileSize,
       this.interactive = false,
       this.appBadgeInfo,
+      this.tileTitleBarInfo,
       super.color,
       super.onPressed,
       this.icon,
@@ -37,24 +44,72 @@ class ButtonTile extends TileWidget implements CoveredTile, FocableElement {
       this.image,
       this.elementValue,
       this.focusNode})
-      : super(tileSize: tileSize);
+      : super(tileSize: tileSize) {
+    focusNode?.setFocucableElement(this);
+  }
+
+  @override
+  State<TileWidget> createState() => _ButtonTileState();
+}
+
+class _ButtonTileState extends TileWidgetState<ButtonTile> {
+  late TileCover _tileCover;
+  late FocusNode _focusNode;
+  TileTitleBar? _titleBar;
+  TileBadges? _tileBadges;
+
+  @override
+  void initState() {
+    super.initState();
+    _tileCover = TileCover(
+      customCover: widget.customCover,
+      icon: widget.icon,
+      image: widget.image,
+      color: widget.color,
+    );
+
+    _focusNode = widget.focusNode ?? FocusNode();
+    if (widget.appBadgeInfo != null)
+      _tileBadges = TileBadges(widget.appBadgeInfo!);
+
+    if (!widget.interactive) return;
+
+    _focusNode.addListener(() {
+      if (!mounted) return;
+
+      setState(() {
+        if (widget.tileTitleBarInfo != null)
+          _titleBar = _focusNode.hasFocus
+              ? TileTitleBar(widget.tileTitleBarInfo!.title)
+              : null;
+        _tileBadges = !_focusNode.hasFocus && widget.appBadgeInfo != null
+            ? TileBadges(widget.appBadgeInfo!)
+            : null;
+      });
+    });
+  }
 
   @override
   Widget virtualBuild(BuildContext context) {
     return Button(
+      focusNode: _focusNode,
       style: ButtonStyle(
           backgroundColor: ButtonState.all(Colors.transparent),
           elevation: ButtonState.all(0),
           padding: ButtonState.all(EdgeInsets.zero)),
-      onPressed: () => onPressed?.call(context),
+      onPressed: () => widget.onPressed?.call(context),
       child: Stack(
         children: [
-          TileCover(
-            customCover: customCover,
-            icon: icon,
-            image: image,
-            color: color,
-          ),
+          _tileCover,
+          Align(
+              alignment: Alignment.bottomLeft,
+              child: Padding(
+                  padding: const EdgeInsets.symmetric(
+                      horizontal: 3.0, vertical: 3.0),
+                  child: _tileBadges ?? const SizedBox())),
+          Align(
+              alignment: Alignment.bottomLeft,
+              child: _titleBar ?? const SizedBox())
         ],
       ),
     );

--- a/lib/shared/widgets/tiles/button_tile.dart
+++ b/lib/shared/widgets/tiles/button_tile.dart
@@ -25,9 +25,6 @@ class ButtonTile extends TileWidget implements CoveredTile, FocableElement {
 
   late bool getFocused;
 
-  late final TileSize _tileSize;
-  TileSize get tileSize => _tileSize;
-
   ButtonTile(String title,
       {super.key,
       required TileSize tileSize,

--- a/lib/shared/widgets/tiles/button_tile.dart
+++ b/lib/shared/widgets/tiles/button_tile.dart
@@ -53,7 +53,6 @@ class ButtonTile extends TileWidget implements CoveredTile, FocableElement {
 }
 
 class _ButtonTileState extends TileWidgetState<ButtonTile> {
-  late TileCover _tileCover;
   late FocusNode _focusNode;
   TileTitleBar? _titleBar;
   TileBadges? _tileBadges;
@@ -61,12 +60,6 @@ class _ButtonTileState extends TileWidgetState<ButtonTile> {
   @override
   void initState() {
     super.initState();
-    _tileCover = TileCover(
-      customCover: widget.customCover,
-      icon: widget.icon,
-      image: widget.image,
-      color: widget.color,
-    );
 
     _focusNode = widget.focusNode ?? FocusNode();
     if (widget.appBadgeInfo != null)
@@ -90,6 +83,12 @@ class _ButtonTileState extends TileWidgetState<ButtonTile> {
   }
 
   @override
+  void dispose() {
+    super.dispose();
+    _focusNode.dispose();
+  }
+
+  @override
   Widget virtualBuild(BuildContext context) {
     return Button(
       focusNode: _focusNode,
@@ -100,7 +99,12 @@ class _ButtonTileState extends TileWidgetState<ButtonTile> {
       onPressed: () => widget.onPressed?.call(context),
       child: Stack(
         children: [
-          _tileCover,
+          TileCover(
+            customCover: widget.customCover,
+            icon: widget.icon,
+            image: widget.image,
+            color: widget.color,
+          ),
           Align(
               alignment: Alignment.bottomLeft,
               child: Padding(

--- a/lib/shared/widgets/tiles/game_button_tile.dart
+++ b/lib/shared/widgets/tiles/game_button_tile.dart
@@ -1,5 +1,6 @@
 import 'package:fluent_ui/fluent_ui.dart';
 import 'package:xbox_launcher/models/app_models/game_model.dart';
+import 'package:xbox_launcher/models/tile_title_bar_info.dart';
 import 'package:xbox_launcher/shared/enums/tile_size.dart';
 import 'package:xbox_launcher/shared/widgets/focus/element_focus_node.dart';
 import 'package:xbox_launcher/shared/widgets/utils/commands/models/command_invoker.dart';
@@ -12,11 +13,11 @@ class GameButtonTile extends ButtonTile {
   GameButtonTile(this.gameModel,
       {Key? key, required TileSize tileSize, ElementFocusNode? focusNode})
       : super(
-          gameModel.name,
           key: key,
           elementValue: gameModel,
           interactive: true,
           appBadgeInfo: gameModel.extraGameProperties.toBadgeInfo(),
+          tileTitleBarInfo: TileTitleBarInfo(gameModel.name),
           tileSize: tileSize,
           image: NetworkImage(gameModel.tileGameImageUrl),
           focusNode: focusNode,

--- a/lib/shared/widgets/tiles/models/covered_tile.dart
+++ b/lib/shared/widgets/tiles/models/covered_tile.dart
@@ -1,8 +1,10 @@
 import 'package:fluent_ui/fluent_ui.dart';
 import 'package:xbox_launcher/models/app_badge_info.dart';
+import 'package:xbox_launcher/models/tile_title_bar_info.dart';
 
 abstract class CoveredTile {
   AppBadgeInfo? appBadgeInfo;
+  TileTitleBarInfo? tileTitleBarInfo;
   IconData? icon;
   Widget? customCover;
 

--- a/lib/shared/widgets/tiles/models/covered_tile.dart
+++ b/lib/shared/widgets/tiles/models/covered_tile.dart
@@ -1,0 +1,10 @@
+import 'package:fluent_ui/fluent_ui.dart';
+import 'package:xbox_launcher/models/app_badge_info.dart';
+
+abstract class CoveredTile {
+  AppBadgeInfo? appBadgeInfo;
+  IconData? icon;
+  Widget? customCover;
+
+  CoveredTile({this.appBadgeInfo, this.icon, this.customCover});
+}

--- a/lib/shared/widgets/tiles/models/tile_widget.dart
+++ b/lib/shared/widgets/tiles/models/tile_widget.dart
@@ -1,7 +1,7 @@
 import 'package:fluent_ui/fluent_ui.dart';
 import 'package:xbox_launcher/shared/enums/tile_size.dart';
 
-abstract class TileWidget extends StatelessWidget {
+abstract class TileWidget extends StatefulWidget {
   void Function(BuildContext)? onPressed;
   late double width;
   late double height;
@@ -33,14 +33,19 @@ abstract class TileWidget extends StatelessWidget {
     }
   }
 
+  @override
+  State<TileWidget> createState();
+}
+
+abstract class TileWidgetState<T extends TileWidget> extends State<T> {
   Widget virtualBuild(BuildContext context);
 
   @override
   Widget build(BuildContext context) {
     return Container(
-      color: color,
-      width: width,
-      height: height,
+      color: widget.color,
+      width: widget.width,
+      height: widget.height,
       child: virtualBuild(context),
     );
   }

--- a/lib/shared/widgets/tiles/models/tile_widget.dart
+++ b/lib/shared/widgets/tiles/models/tile_widget.dart
@@ -1,0 +1,47 @@
+import 'package:fluent_ui/fluent_ui.dart';
+import 'package:xbox_launcher/shared/enums/tile_size.dart';
+
+abstract class TileWidget extends StatelessWidget {
+  void Function(BuildContext)? onPressed;
+  late double width;
+  late double height;
+  TileSize tileSize;
+  Color? color;
+
+  TileWidget(
+      {super.key,
+      required this.tileSize,
+      required this.color,
+      this.onPressed}) {
+    switch (tileSize) {
+      case TileSize.SMALL:
+        width = 100;
+        height = 100;
+        break;
+      case TileSize.MEDIUM:
+        width = 150;
+        height = 150;
+        break;
+      case TileSize.BIG:
+        width = 300;
+        height = 300;
+        break;
+      case TileSize.LENGHTY:
+        width = 200;
+        height = 100;
+        break;
+    }
+  }
+
+  Widget virtualBuild(BuildContext context);
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      color: color,
+      width: width,
+      height: height,
+      child: virtualBuild(context),
+    );
+  }
+}

--- a/lib/shared/widgets/tiles/system_app_tile.dart
+++ b/lib/shared/widgets/tiles/system_app_tile.dart
@@ -1,7 +1,9 @@
 import 'package:fluent_ui/fluent_ui.dart';
 import 'package:xbox_launcher/models/app_models/system_app_model.dart';
+import 'package:xbox_launcher/models/tile_title_bar_info.dart';
 import 'package:xbox_launcher/shared/enums/tile_size.dart';
 import 'package:xbox_launcher/shared/widgets/focus/element_focus_node.dart';
+import 'package:xbox_launcher/shared/widgets/tiles/tile_title_bar.dart';
 import 'package:xbox_launcher/shared/widgets/utils/commands/models/command_invoker.dart';
 import 'package:xbox_launcher/shared/widgets/utils/commands/open_app_command.dart';
 import 'package:xbox_launcher/shared/widgets/tiles/button_tile.dart';
@@ -14,15 +16,17 @@ class SystemAppButtonTile extends ButtonTile {
       required BuildContext context, //Context to navigate
       required TileSize tileSize,
       ElementFocusNode? focusNode})
-      : super(appModel.name,
+      : super(
             interactive: true,
             key: key,
+            tileTitleBarInfo: TileTitleBarInfo(appModel.name),
             tileSize: tileSize,
             elementValue: appModel,
             focusNode: focusNode,
-            icon: appModel.icon, onPressed: (_) {
-          CommandInvoker command =
-              CommandInvoker(OpenAppCommand(appModel, context: context));
-          command.execute();
-        });
+            icon: appModel.icon,
+            onPressed: (_) {
+              CommandInvoker command =
+                  CommandInvoker(OpenAppCommand(appModel, context: context));
+              command.execute();
+            });
 }

--- a/lib/shared/widgets/tiles/utils/tiles_generator.dart
+++ b/lib/shared/widgets/tiles/utils/tiles_generator.dart
@@ -1,0 +1,46 @@
+import 'package:xbox_launcher/models/app_models/app_model.dart';
+import 'package:xbox_launcher/models/app_models/game_model.dart';
+import 'package:xbox_launcher/models/app_models/system_app_model.dart';
+import 'package:xbox_launcher/shared/enums/app_type.dart';
+import 'package:xbox_launcher/shared/enums/tile_size.dart';
+import 'package:xbox_launcher/shared/widgets/focus/element_focus_node.dart';
+import 'package:xbox_launcher/shared/widgets/tiles/game_button_tile.dart';
+import 'package:xbox_launcher/shared/widgets/tiles/models/tile_widget.dart';
+import 'package:xbox_launcher/shared/widgets/tiles/system_app_tile.dart';
+import 'package:xbox_launcher/shared/widgets/utils/generators/models/tile_generator_option.dart';
+
+abstract class TileGenerator {
+  List<TileWidget> generateByModel(List<AppModel> appModels, TileSize tilesSize,
+      TileGeneratorOption option) {
+    List<TileWidget> tiles = List.empty(growable: true);
+
+    for (AppModel model in appModels) {
+      TileWidget tile;
+      ElementFocusNode? focusNode = option.focusScope?.createFocusNode();
+
+      switch (model.appType) {
+        case AppType.GAME:
+          tile = GameButtonTile(
+            model as GameModel,
+            tileSize: tilesSize,
+            focusNode: focusNode,
+          );
+          break;
+        case AppType.SYSTEM_APP:
+          tile = SystemAppButtonTile(
+            model as SystemAppModel,
+            tileSize: tilesSize,
+            context: option.context,
+            focusNode: focusNode,
+          );
+          break;
+        default:
+          throw UnimplementedError(
+              model.runtimeType.toString() + " not implemented yet.");
+      }
+      tiles.add(tile);
+    }
+
+    return tiles;
+  }
+}

--- a/lib/shared/widgets/utils/generators/models/tile_generator_option.dart
+++ b/lib/shared/widgets/utils/generators/models/tile_generator_option.dart
@@ -1,11 +1,9 @@
 import 'package:fluent_ui/fluent_ui.dart';
-import 'package:xbox_launcher/shared/enums/tile_size.dart';
 import 'package:xbox_launcher/shared/widgets/focus/element_focus_scope.dart';
 
 class TileGeneratorOption {
-  List<TileSize> sizes;
   BuildContext context;
   ElementFocusScope? focusScope;
 
-  TileGeneratorOption(this.sizes, {required this.context, this.focusScope});
+  TileGeneratorOption({this.focusScope, required this.context});
 }

--- a/lib/shared/widgets/utils/generators/widget_gen.dart
+++ b/lib/shared/widgets/utils/generators/widget_gen.dart
@@ -1,15 +1,5 @@
 import 'package:fluent_ui/fluent_ui.dart';
-import 'package:xbox_launcher/models/app_models/app_model.dart';
-import 'package:xbox_launcher/models/app_models/game_model.dart';
-import 'package:xbox_launcher/models/app_models/system_app_model.dart';
-import 'package:xbox_launcher/shared/enums/app_type.dart';
-import 'package:xbox_launcher/shared/enums/tile_size.dart';
-import 'package:xbox_launcher/shared/widgets/focus/element_focus_node.dart';
-import 'package:xbox_launcher/shared/widgets/tiles/game_button_tile.dart';
-import 'package:xbox_launcher/shared/widgets/tiles/system_app_tile.dart';
-import 'package:xbox_launcher/shared/widgets/tiles/tile_base.dart';
 import 'package:xbox_launcher/shared/widgets/utils/generators/models/cover_generation_options.dart';
-import 'package:xbox_launcher/shared/widgets/utils/generators/models/tile_generator_option.dart';
 
 class WidgetGen {
   static Widget generateTileCover(
@@ -56,42 +46,5 @@ class WidgetGen {
     }
 
     return _tileCover;
-  }
-
-  static List<TileBase> generateByModel(
-      List<AppModel> appModels, TileGeneratorOption option) {
-    List<TileBase> tiles = List.empty(growable: true);
-
-    for (AppModel model in appModels) {
-      TileBase tile;
-      TileSize actualTileSize = tiles.length >= option.sizes.length
-          ? option.sizes.last
-          : option.sizes[tiles.length];
-      ElementFocusNode? focusNode = option.focusScope?.createFocusNode();
-
-      switch (model.appType) {
-        case AppType.GAME:
-          tile = GameButtonTile(
-            model as GameModel,
-            tileSize: actualTileSize,
-            focusNode: focusNode,
-          );
-          break;
-        case AppType.SYSTEM_APP:
-          tile = SystemAppButtonTile(
-            model as SystemAppModel,
-            tileSize: actualTileSize,
-            context: option.context,
-            focusNode: focusNode,
-          );
-          break;
-        default:
-          throw UnimplementedError(
-              model.runtimeType.toString() + " not implemented yet.");
-      }
-      tiles.add(tile);
-    }
-
-    return tiles;
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -42,7 +42,7 @@ packages:
       name: carousel_slider
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.1.1"
+    version: "4.2.1"
   characters:
     dependency: transitive
     description:
@@ -98,14 +98,14 @@ packages:
       name: file_picker
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.1.0"
+    version: "5.2.4"
   fluent_ui:
     dependency: "direct main"
     description:
       name: fluent_ui
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.0.3+1"
+    version: "4.1.2"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -136,7 +136,7 @@ packages:
       name: flutter_svg
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.5"
+    version: "1.1.6"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -321,7 +321,7 @@ packages:
       name: provider
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.0.3"
+    version: "6.0.5"
   recase:
     dependency: transitive
     description:
@@ -335,7 +335,7 @@ packages:
       name: screen_retriever
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.2"
+    version: "0.1.4"
   scroll_pos:
     dependency: transitive
     description:
@@ -417,7 +417,7 @@ packages:
       name: sprintf
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.0.2"
+    version: "7.0.0"
   stack_trace:
     dependency: transitive
     description:
@@ -473,7 +473,7 @@ packages:
       name: url_launcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.1.6"
+    version: "6.1.7"
   url_launcher_android:
     dependency: transitive
     description:
@@ -545,7 +545,7 @@ packages:
       name: webview_windows
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.1"
+    version: "0.2.2"
   win32:
     dependency: transitive
     description:
@@ -559,7 +559,7 @@ packages:
       name: window_manager
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.7"
+    version: "0.2.8"
   xdg_directories:
     dependency: transitive
     description:
@@ -573,7 +573,7 @@ packages:
       name: xinput_gamepad
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.2.3"
   xml:
     dependency: transitive
     description:
@@ -590,4 +590,4 @@ packages:
     version: "3.1.1"
 sdks:
   dart: ">=2.18.1 <3.0.0"
-  flutter: ">=3.0.0"
+  flutter: ">=3.3.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,23 +9,23 @@ dependencies:
   flutter:
     sdk: flutter
 
-  fluent_ui: ^4.0.3
-  webview_windows: ^0.2.1
-  provider: ^6.0.3
-  xinput_gamepad: ^1.2.0
+  fluent_ui: ^4.1.2
+  webview_windows: ^0.2.2
+  provider: ^6.0.5
+  xinput_gamepad: ^1.2.3
   virtual_keyboard:
     git: https://github.com/LuanRoger/virtual_keyboard
   clock: ^1.1.1
-  window_manager: ^0.2.7
+  window_manager: ^0.2.8
   shared_preferences: ^2.0.15
-  file_picker: ^5.0.1
-  sprintf: ^6.0.2
-  carousel_slider: ^4.1.1
+  file_picker: ^5.2.4
+  sprintf: ^7.0.0
+  carousel_slider: ^4.2.1
   path_provider: ^2.0.11
-  flutter_svg: ^1.1.5
+  flutter_svg: ^1.1.6
   sys_info_getter:
     path: ./internals/sys_info_getter/
-  url_launcher: ^6.1.6
+  url_launcher: ^6.1.7
   path: ^1.8.2
 
 dev_dependencies:

--- a/tools/internals/element_picker.py
+++ b/tools/internals/element_picker.py
@@ -9,6 +9,13 @@ from .xcloud_elements_consts import SUPPORTED_INPUTS_CONTAINER, GAME_INFO_BOX_XP
 from .webdriver_utils import *
 from .utils.url_formater import *
 
+def getTileGameImageUrl(gamePicture) -> str:
+    img_element = gamePicture.find_element(by=By.TAG_NAME, value="img")
+    image_src_set: str = img_element.get_attribute("srcset").split(',')
+
+    image_src = image_src_set[1][:-2].strip()
+    return image_src
+
 def getGamesInGrid(grid) -> Any:
     return grid.find_elements(by=By.TAG_NAME, value="a")
 
@@ -50,12 +57,12 @@ def getGamesProperties(gameInfoContainer) -> GameProperties:
     except:
         pass
 
-    supported_controller_container = gameInfoContainer.find_element(by=By.CLASS_NAME, value=SUPPORTED_INPUTS_CONTAINER)
-    supported_controller_divs = supported_controller_container.find_elements(by=By.TAG_NAME, value="div")
+    supported_inputs_container = gameInfoContainer.find_element(by=By.CLASS_NAME, value=SUPPORTED_INPUTS_CONTAINER).find_element(by=By.TAG_NAME, value="div")
+    supported_inputs = supported_inputs_container.find_elements(by=By.TAG_NAME, value="svg")
 
-    d = len(supported_controller_divs)
-    support_controller: bool = len(supported_controller_divs) >= 2
-    touch_controller: bool = len(supported_controller_divs) >= 4
+    d = len(supported_inputs)
+    support_controller: bool = len(supported_inputs) >= 1
+    touch_controller: bool = len(supported_inputs) >= 2
 
     return GameProperties(is_in_gamepass, support_controller, touch_controller)
 

--- a/tools/internals/utils/url_formater.py
+++ b/tools/internals/utils/url_formater.py
@@ -8,14 +8,11 @@ def add_parameter_sprinter(url: str) -> str:
     arguments = url[argument_start:]
 
     width_start = arguments.find("w=") + 2
-    height_start = arguments.find("h=") + 2
     widht = arguments[width_start : width_start + 3]
-    height = arguments[height_start : height_start + 3]
     
     arguments = arguments.replace(widht, "%i", 1)
-    arguments = arguments.replace(height, "%i", 1)
 
-    return url[:argument_start] + arguments
+    return "https:" + url[:argument_start] + arguments
     
 def format_hero_image(url: str) -> str:
     if(url is None): return None

--- a/tools/xcloud_extras_picker.py
+++ b/tools/xcloud_extras_picker.py
@@ -5,7 +5,7 @@ from internals.models.xcloud_game import XcloudGame
 
 from xcloud_extras.consts import *
 from internals.shared_consts import XCLOUD_BASE_URL
-from internals.element_picker import getGamesInGrid, getGamesInfoInNewTab
+from internals.element_picker import getGamesInGrid, getGamesInfoInNewTab, getTileGameImageUrl
 from internals.webdriver_utils import *
 from internals.xcloud_elements_consts import *
 from internals.json_writer import *
@@ -19,8 +19,8 @@ games = getGamesInGrid(games_grid)
 games_list: List[XcloudGame] = []
 for game in games:
     game_url: str = game.get_attribute("href")
-    game_image_element = game.find_element(by=By.TAG_NAME, value="img")
-    tile_image_url = add_parameter_sprinter(game_image_element.get_attribute("src"))
+    game_image_src: str = getTileGameImageUrl(game.find_element(by=By.TAG_NAME, value="picture"))
+    tile_image_url = add_parameter_sprinter(game_image_src)
 
     xcloud_game = getGamesInfoInNewTab(driver, game_url)
     xcloud_game.xcloudUrl = add_formater_game_url_server(game_url, XCLOUD_BASE_URL)

--- a/tools/xcloud_game_picker.py
+++ b/tools/xcloud_game_picker.py
@@ -7,7 +7,7 @@ from xcloud_game.consts import GAMES_JSON_FILE_PATH
 from internals.utils.url_formater import *
 from xcloud_game.consts import *
 from internals.shared_consts import XCLOUD_BASE_URL
-from internals.element_picker import getGamesInfoInNewTab, getGamesInGrid
+from internals.element_picker import getGamesInfoInNewTab, getGamesInGrid, getTileGameImageUrl
 from internals.webdriver_utils import *
 from internals.xcloud_elements_consts import *
 from internals.models.xcloud_game import XcloudGame
@@ -27,8 +27,8 @@ while not done:
         if(add_formater_game_url_server(game_url, XCLOUD_BASE_URL) in [geted_game.xcloudUrl for geted_game in games_list]):
             continue
         
-        game_image_element = game.find_element(by=By.TAG_NAME, value="img")
-        tile_image_url = add_parameter_sprinter(game_image_element.get_attribute("src"))
+        game_image_src: str = getTileGameImageUrl(game.find_element(by=By.TAG_NAME, value="picture"))
+        tile_image_url = add_parameter_sprinter(game_image_src)
 
         xcloud_game = getGamesInfoInNewTab(driver, game_url)
         if(xcloud_game == None):

--- a/tools/xcloud_games.json
+++ b/tools/xcloud_games.json
@@ -9,11 +9,11 @@
         "releaseDate": "27/06/2016",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/7-days-to-die/BRL7GC0GP1BM",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.50759.69802328231064156.03ff84cc-b6b1-4226-8e6c-545d183e5fbf.6c46b7d8-06fd-4959-8342-440580385ce9?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.50759.69802328231064156.03ff84cc-b6b1-4226-8e6c-545d183e5fbf.6c46b7d8-06fd-4959-8342-440580385ce9?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.21205.69802328231064156.03ff84cc-b6b1-4226-8e6c-545d183e5fbf.dfb75b7e-4f40-4461-a762-0911a780e985?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/7-days-to-die/BRL7GC0GP1BM"
     },
@@ -27,11 +27,11 @@
         "releaseDate": "24/03/2022",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/a-memoir-blue/9NL4KTK0N4CG",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.55802.13714290489749263.fa316741-1615-4cad-942c-7c2fddc7b069.86d4a18f-cf41-4fa9-92af-8c95ca311c96?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.55802.13714290489749263.fa316741-1615-4cad-942c-7c2fddc7b069.86d4a18f-cf41-4fa9-92af-8c95ca311c96?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.12478.13714290489749263.fa316741-1615-4cad-942c-7c2fddc7b069.f1bbf8b2-4ab6-4295-8bea-d41b506e812a?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/a-memoir-blue/9NL4KTK0N4CG"
     },
@@ -46,11 +46,11 @@
         "releaseDate": "18/10/2022",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/a-plague-tale-requiem/9ND0JVB184XL",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.60562.13558336166432541.beb57fbe-cc4b-40c5-ba76-c8112867dea2.9a69e497-4f9f-495d-9ac6-f8956b491d91?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.60562.13558336166432541.beb57fbe-cc4b-40c5-ba76-c8112867dea2.9a69e497-4f9f-495d-9ac6-f8956b491d91?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.59830.13558336166432541.beb57fbe-cc4b-40c5-ba76-c8112867dea2.f764a45c-f860-483f-b264-aa9041f2bb62?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/a-plague-tale-requiem/9ND0JVB184XL"
     },
@@ -65,12 +65,12 @@
         "releaseDate": "22/11/2021",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/anvil-vault-breaker-game-preview/9PJPV2PC3MWR",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.19212.14277836659846754.5f133eeb-446d-45d9-bc2f-294eea5a641c.54b4f184-784c-427a-ae39-4b1463a58a57?w=%i&h=%i",
-        "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.25606.14277836659846754.5f133eeb-446d-45d9-bc2f-294eea5a641c.946c1f7e-7d81-4650-b287-12f6588cac1b?h=%i&format=jpg",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.703.14277836659846754.c5a47e72-eaf6-491d-a9b6-416bdb5f5d33.2f83f8b9-819b-487c-9378-aca2565c9e02?w=%i&format=jpg",
+        "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.35692.14277836659846754.c5a47e72-eaf6-491d-a9b6-416bdb5f5d33.ac699555-bbe1-42e6-89c5-75726da01fbe?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/anvil-vault-breaker-game-preview/9PJPV2PC3MWR"
     },
     {
@@ -83,11 +83,11 @@
         "releaseDate": "26/05/2021",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/ark-ultimate-survivor-edition/9N5JRWWGMS1R",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.14842.14036931078975578.35527dd4-bd1c-43d9-90ff-3a801a47df6a.e296f313-9109-4635-a3cb-14b747fb2230?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.14842.14036931078975578.35527dd4-bd1c-43d9-90ff-3a801a47df6a.e296f313-9109-4635-a3cb-14b747fb2230?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.30358.14036931078975578.35527dd4-bd1c-43d9-90ff-3a801a47df6a.871f208d-e7ba-4898-b725-e9e3d3f90797?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/ark-ultimate-survivor-edition/9N5JRWWGMS1R"
     },
@@ -102,32 +102,49 @@
         "releaseDate": "05/02/2019",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/astroneer/9NBLGGH43KZB",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.64849.13510798887933723.57e43f19-4066-429e-b1a2-caea56e427b4.860c35a4-ccbf-413e-9574-1c7c8826d6c6?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.64849.13510798887933723.57e43f19-4066-429e-b1a2-caea56e427b4.860c35a4-ccbf-413e-9574-1c7c8826d6c6?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.29512.13510798887933723.2e918b0b-2171-4602-baa4-ab1677624f25.465577c8-a626-4bf3-b4a1-19911855c773?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/astroneer/9NBLGGH43KZB"
     },
     {
-        "gameTitle": "Aliens: Fireteam Elite",
-        "gamePublisher": "Cold Iron Studios",
-        "gameDeveloper": "Cold Iron Studios",
+        "gameTitle": "Amnesia: Collection",
+        "gamePublisher": "Frictional Games",
+        "gameDeveloper": "Frictional Games",
         "gameGenres": [
-            "A\u00e7\u00e3o e aventura",
-            "Jogos de tiros"
+            "A\u00e7\u00e3o e aventura"
         ],
-        "releaseDate": "24/08/2021",
+        "releaseDate": "27/09/2018",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
-        "xcloudUrl": "https://www.xbox.com/%s/play/games/aliens-fireteam-elite/9PG28RXDG9GQ",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.59370.14189206062547849.34667497-3c97-48d3-916d-0cd555e3aee9.2a32a391-5b37-4ec9-9fc1-7bb4159de6b9?w=%i&h=%i",
-        "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.30369.14189206062547849.34667497-3c97-48d3-916d-0cd555e3aee9.057ac9cb-1d5f-4c0e-b5bc-7a78774595a7?h=%i&format=jpg",
-        "storeUrl": "https://www.xbox.com/games/store/aliens-fireteam-elite/9PG28RXDG9GQ"
+        "xcloudUrl": "https://www.xbox.com/%s/play/games/amnesia-collection/BV02TBL15DX3",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.38348.70644597693904836.cde9dd08-509f-4054-8190-24728e59ad5e.3d59232d-5678-4cf5-abaf-d4371ea14d51?w=%i&format=jpg",
+        "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.22053.70644597693904836.cde9dd08-509f-4054-8190-24728e59ad5e.2b82c70a-d4a8-4219-9513-8b03beb30874?h=%i&format=jpg",
+        "storeUrl": "https://www.xbox.com/games/store/amnesia-collection/BV02TBL15DX3"
+    },
+    {
+        "gameTitle": "Amnesia: Rebirth",
+        "gamePublisher": "Frictional Games",
+        "gameDeveloper": "Frictional Games",
+        "gameGenres": [
+            "A\u00e7\u00e3o e aventura"
+        ],
+        "releaseDate": "19/10/2022",
+        "extraGameProperties": {
+            "isInGamePass": true,
+            "controllerSupport": true,
+            "touchControllerSupport": true
+        },
+        "xcloudUrl": "https://www.xbox.com/%s/play/games/amnesia-rebirth/9PMM21KVRD72",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.43953.14290925569393643.f558cfd6-0d70-43e7-aaba-ddbe80b67784.48c00b8a-ec33-43e2-a4d2-083e95994d98?w=%i&format=jpg",
+        "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.55682.14290925569393643.f558cfd6-0d70-43e7-aaba-ddbe80b67784.191af0e3-0ee9-4e86-9358-e5808381ec7e?h=%i&format=jpg",
+        "storeUrl": "https://www.xbox.com/games/store/amnesia-rebirth/9PMM21KVRD72"
     },
     {
         "gameTitle": "Among Us",
@@ -139,11 +156,11 @@
         "releaseDate": "13/12/2021",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/among-us/9NG07QJNK38J",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.21162.13589262686196899.16e3418a-cbf2-4748-9724-1c9dc9b7a0b9.14afafe9-1b03-4df0-95ad-12e2712a3b53?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.21162.13589262686196899.16e3418a-cbf2-4748-9724-1c9dc9b7a0b9.14afafe9-1b03-4df0-95ad-12e2712a3b53?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.14626.13589262686196899.12354b81-d410-4255-b6aa-9f9a68a694ae.dec2ecaf-85b7-4792-b5aa-13c1a3b31c5e?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/among-us/9NG07QJNK38J"
     },
@@ -157,32 +174,13 @@
         "releaseDate": "16/09/2021",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/aragami-2/9PN9WG83X4XF",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.22986.14347616248294866.f2c12ab4-ed34-4e28-b51d-b89260f65198.c2f48fe0-70e2-4a54-af39-02de867401ba?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.22986.14347616248294866.f2c12ab4-ed34-4e28-b51d-b89260f65198.c2f48fe0-70e2-4a54-af39-02de867401ba?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.17371.14347616248294866.82c078ff-2f36-4b77-be61-2ddf95968bb4.e8483161-dc38-40ac-8ad4-902baf34e5cf?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/aragami-2/9PN9WG83X4XF"
-    },
-    {
-        "gameTitle": "Archvale",
-        "gamePublisher": "Humble Games",
-        "gameDeveloper": "idoz & phops",
-        "gameGenres": [
-            "A\u00e7\u00e3o e aventura",
-            "RPG"
-        ],
-        "releaseDate": "02/12/2021",
-        "extraGameProperties": {
-            "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
-        },
-        "xcloudUrl": "https://www.xbox.com/%s/play/games/archvale/9P3MGM8ZCS5D",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.20086.14539916772838877.ac2b2d42-d84b-4c24-8fe1-11b90b3ed1f0.291df9fa-27ba-42d9-b74b-40c45a59f1b8?w=%i&h=%i",
-        "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.48975.14539916772838877.ac2b2d42-d84b-4c24-8fe1-11b90b3ed1f0.a216b11a-a1bc-401f-9180-09ef084ba48a?h=%i&format=jpg",
-        "storeUrl": "https://www.xbox.com/games/store/archvale/9P3MGM8ZCS5D"
     },
     {
         "gameTitle": "As Dusk Falls",
@@ -195,11 +193,11 @@
         "releaseDate": "19/07/2022",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/as-dusk-falls/9NR7XDNVP5SW",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.46746.14387733153613072.28665954-14dc-4229-8e3c-0257e25089cb.46b89faa-6b2f-433b-aefc-16e5063ea2af?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.46746.14387733153613072.28665954-14dc-4229-8e3c-0257e25089cb.46b89faa-6b2f-433b-aefc-16e5063ea2af?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.20006.14387733153613072.563f42df-3a88-4df7-999d-62897cc0ccde.a7393a26-d54a-42bd-b304-886b4dfb025d?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/as-dusk-falls/9NR7XDNVP5SW"
     },
@@ -213,11 +211,11 @@
         "releaseDate": "04/10/2018",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/assassin's-creed-odyssey/BW9TWC8L4JCS",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.45811.71972716530068101.91350a92-63c5-4583-96a7-c8e03d0d6c67.a5f46c28-e00c-40a7-b5e0-a723a407bb16?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.35106.71972716530068101.ccdcadf1-1d2a-49f2-9c37-0b0a27e5a53c.a31a0259-3502-4887-9b7b-289643a3986c?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.53783.71972716530068101.ccdcadf1-1d2a-49f2-9c37-0b0a27e5a53c.6d60329c-2f2a-4ac9-9dd3-2f132d5c3b6c?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/assassin's-creed-odyssey/BW9TWC8L4JCS"
     },
@@ -231,11 +229,11 @@
         "releaseDate": "26/10/2017",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/assassin's-creed-origins/BZGJRJC1FGF3",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.24317.63657969076271726.d61cc1bb-fe99-40ef-b061-bded231757be.c17f684c-0c90-4d39-911e-8bd8c0622587?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.12595.63657969076271726.154f5a09-55ab-4b31-bc57-4e0335fab06a.483a88b2-de82-4242-a2cf-844ae658fde1?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.51508.63657969076271726.154f5a09-55ab-4b31-bc57-4e0335fab06a.8c56d9de-b95f-4f50-931b-818bc7d5711c?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/assassin's-creed-origins/BZGJRJC1FGF3"
     },
@@ -249,11 +247,11 @@
         "releaseDate": "16/04/2018",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/blinx-the-time-sweeper/BRG51C5MWFSG",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.1712.69676224553003885.7746d59f-9224-4b66-8097-e540a8ad4b00.a2e18719-7a03-42b0-9324-907f92092527?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.1712.69676224553003885.7746d59f-9224-4b66-8097-e540a8ad4b00.a2e18719-7a03-42b0-9324-907f92092527?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.12688.69676224553003885.7746d59f-9224-4b66-8097-e540a8ad4b00.f5dd36da-c5f1-412a-83a3-257dfeb1ab0d?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/blinx-the-time-sweeper/BRG51C5MWFSG"
     },
@@ -267,31 +265,13 @@
         "releaseDate": "11/10/2021",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/back-4-blood/BXLL06QN8HVP",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.49309.63183727176145146.d84d29ef-df3a-4a5d-96b4-f1a7d9797aec.7b42c961-b9e0-484c-b079-f461f64e1f53?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.49309.63183727176145146.d84d29ef-df3a-4a5d-96b4-f1a7d9797aec.7b42c961-b9e0-484c-b079-f461f64e1f53?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.19877.63183727176145146.d84d29ef-df3a-4a5d-96b4-f1a7d9797aec.681271f3-8d03-4b06-a356-b7d53722ea8d?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/back-4-blood/BXLL06QN8HVP"
-    },
-    {
-        "gameTitle": "Backbone",
-        "gamePublisher": "Raw Fury",
-        "gameDeveloper": "Eggnut",
-        "gameGenres": [
-            "A\u00e7\u00e3o e aventura"
-        ],
-        "releaseDate": "07/06/2021",
-        "extraGameProperties": {
-            "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
-        },
-        "xcloudUrl": "https://www.xbox.com/%s/play/games/backbone/9NC9TNXS9C8G",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.3533.13571577878997765.bf0e584f-1da0-45dc-9616-f8707de4bf08.688aec25-927e-4198-b219-643c650b7930?w=%i&h=%i",
-        "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.51040.13571577878997765.bf0e584f-1da0-45dc-9616-f8707de4bf08.1774e625-9436-4f3c-a1c3-545d1d103e1b?h=%i&format=jpg",
-        "storeUrl": "https://www.xbox.com/games/store/backbone/9NC9TNXS9C8G"
     },
     {
         "gameTitle": "Banjo Kazooie: N n B",
@@ -304,11 +284,11 @@
         "releaseDate": "02/08/2010",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/banjo-kazooie-n-n-b/BVR64CDJ01FJ",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.34826.71100151761088573.88824642-fc7e-4e99-9b5b-32e26f7c27b9.8a1cccf6-01d0-48c6-bd1a-0d03df399bba?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.34826.71100151761088573.88824642-fc7e-4e99-9b5b-32e26f7c27b9.8a1cccf6-01d0-48c6-bd1a-0d03df399bba?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.32292.71100151761088573.88824642-fc7e-4e99-9b5b-32e26f7c27b9.623b6c28-ef2b-4ce0-81b1-6605506c5483?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/banjo-kazooie-n-n-b/BVR64CDJ01FJ"
     },
@@ -323,11 +303,11 @@
         "releaseDate": "10/01/2010",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/banjo-kazooie/BSJG7TTSWVJ2",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.58897.70306648669442933.0ad02883-9547-43ed-a595-2a807684ce15.fa8d898f-1097-46fa-b35d-22ceefda2a7a?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.58897.70306648669442933.0ad02883-9547-43ed-a595-2a807684ce15.fa8d898f-1097-46fa-b35d-22ceefda2a7a?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.14529.70306648669442933.0ad02883-9547-43ed-a595-2a807684ce15.9d0de285-8d54-44e2-9511-e809431c6153?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/banjo-kazooie/BSJG7TTSWVJ2"
     },
@@ -342,32 +322,13 @@
         "releaseDate": "22/06/2010",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/banjo-tooie/BX27S00SKW1V",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.2699.63435052096425467.cd1eef72-5707-4f2b-807d-ab3c5baf858c.9ebaa8fc-f1bf-49e8-93fd-62833dbb6b26?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.2699.63435052096425467.cd1eef72-5707-4f2b-807d-ab3c5baf858c.9ebaa8fc-f1bf-49e8-93fd-62833dbb6b26?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.9738.63435052096425467.cd1eef72-5707-4f2b-807d-ab3c5baf858c.45f7306e-e034-4a55-a580-569c4f0d4d67?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/banjo-tooie/BX27S00SKW1V"
-    },
-    {
-        "gameTitle": "Bassmaster\u00ae Fishing 2022",
-        "gamePublisher": "Dovetail Games - Fishing",
-        "gameDeveloper": "Dovetail Games",
-        "gameGenres": [
-            "Simula\u00e7\u00e3o",
-            "Esportes"
-        ],
-        "releaseDate": "27/10/2021",
-        "extraGameProperties": {
-            "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
-        },
-        "xcloudUrl": "https://www.xbox.com/%s/play/games/bassmaster-fishing-2022/9MTTMQ6WSDP8",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.64699.13801370712672953.31e1b8c9-9ecc-4cb2-935c-21a9de3e2027.d4b695ec-a36d-4be2-b2d7-f0ff46f4de0d?w=%i&h=%i",
-        "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.40177.13801370712672953.31e1b8c9-9ecc-4cb2-935c-21a9de3e2027.41a44ed6-38ba-482c-84c7-c67e6ed0dbdf?h=%i&format=jpg",
-        "storeUrl": "https://www.xbox.com/games/store/bassmaster-fishing-2022/9MTTMQ6WSDP8"
     },
     {
         "gameTitle": "Batman\u2122: Arkham Knight",
@@ -379,11 +340,11 @@
         "releaseDate": "22/06/2015",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/batman-arkham-knight/BSLX1RNXR6H7",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.50680.69836087516172366.d802940c-fd8a-4174-8a68-e41a2475e1a1.efa1f648-fb98-4078-80cf-06f47811b1fa?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.50680.69836087516172366.d802940c-fd8a-4174-8a68-e41a2475e1a1.efa1f648-fb98-4078-80cf-06f47811b1fa?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.30637.69836087516172366.d802940c-fd8a-4174-8a68-e41a2475e1a1.77b11b55-654c-4be3-8804-09728b3a6901?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/batman-arkham-knight/BSLX1RNXR6H7"
     },
@@ -397,11 +358,11 @@
         "releaseDate": "21/11/2013",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/battlefield-4/BP15SF17LH13",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.18274.67660042887481018.7de2bfcd-48ef-4a6c-bba4-e65d208d67ec.f299bd07-f6b3-4870-b5e6-786c0a4c3e92?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.18274.67660042887481018.7de2bfcd-48ef-4a6c-bba4-e65d208d67ec.f299bd07-f6b3-4870-b5e6-786c0a4c3e92?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.27970.67660042887481018.7de2bfcd-48ef-4a6c-bba4-e65d208d67ec.238fb864-efda-47a0-a54e-bc7b2ef112c5?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/battlefield-4/BP15SF17LH13"
     },
@@ -415,13 +376,31 @@
         "releaseDate": "20/08/2017",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/battlefield-1-revolution/BPL68T0XK96W",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.39800.68596255437297164.99e6fb73-cd5e-440f-90c2-d8d2eb40a69d.5d9b9ea9-9816-4492-82df-fefa1a6c0f94?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.39800.68596255437297164.99e6fb73-cd5e-440f-90c2-d8d2eb40a69d.5d9b9ea9-9816-4492-82df-fefa1a6c0f94?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.20517.68596255437297164.99e6fb73-cd5e-440f-90c2-d8d2eb40a69d.b89ed24d-ec2e-4720-a295-935fdbc37f7f?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/battlefield-1-revolution/BPL68T0XK96W"
+    },
+    {
+        "gameTitle": "Battlefield\u2122 2042 (Xbox Series X|S)",
+        "gamePublisher": "Electronic Arts",
+        "gameDeveloper": "DICE",
+        "gameGenres": [
+            "Jogos de tiros"
+        ],
+        "releaseDate": "01/06/2021",
+        "extraGameProperties": {
+            "isInGamePass": true,
+            "controllerSupport": true,
+            "touchControllerSupport": false
+        },
+        "xcloudUrl": "https://www.xbox.com/%s/play/games/battlefield-2042-xbox-series-x%7Cs/9P0T51BDDWVT",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.64912.14524595367279766.5574916c-be72-4bad-ab36-3d4205eb1ab8.3b64ab3a-93aa-40c0-bbdb-ac8057860c3b?w=%i&format=jpg",
+        "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.17097.14524595367279766.5574916c-be72-4bad-ab36-3d4205eb1ab8.1846326a-6469-4198-afd0-d54839d905e5?h=%i&format=jpg",
+        "storeUrl": "https://www.xbox.com/games/store/battlefield-2042-xbox-series-x%7Cs/9P0T51BDDWVT"
     },
     {
         "gameTitle": "Battlefield\u2122 V",
@@ -433,11 +412,11 @@
         "releaseDate": "19/11/2018",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/battlefield-v/BZ2N7TQ0XCF2",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.242.64032621253256243.9745cf01-8239-4973-8193-31de18936f03.a8c3c497-3428-45cb-85b3-d84dcb2743bd?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.242.64032621253256243.9745cf01-8239-4973-8193-31de18936f03.a8c3c497-3428-45cb-85b3-d84dcb2743bd?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.17271.64032621253256243.9745cf01-8239-4973-8193-31de18936f03.29cc6447-5d53-494e-866f-9579da2611c9?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/battlefield-v/BZ2N7TQ0XCF2"
     },
@@ -452,11 +431,11 @@
         "releaseDate": "19/08/2020",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/battletoads/9N7GCF5SGCXC",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.14695.14065499269907016.670ddf59-3954-4cfa-927c-60562b664545.56c9f977-b0a8-4b8e-8644-609b768fbc51?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.14695.14065499269907016.670ddf59-3954-4cfa-927c-60562b664545.56c9f977-b0a8-4b8e-8644-609b768fbc51?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.11695.14065499269907016.249670e2-cad9-48bb-aa0f-309d712ede80.314fc433-a37a-49dc-8282-714cca415277?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/battletoads/9N7GCF5SGCXC"
     },
@@ -471,11 +450,11 @@
         "releaseDate": "22/09/2022",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/beacon-pines/9P4R2M0NRWNK",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.23560.14588206397851258.078192f2-519f-4a81-b68d-2dbd6199f2c2.af953250-54af-4a2a-be0c-163b68917421?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.23560.14588206397851258.078192f2-519f-4a81-b68d-2dbd6199f2c2.af953250-54af-4a2a-be0c-163b68917421?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.39650.14588206397851258.078192f2-519f-4a81-b68d-2dbd6199f2c2.0f659ae9-51f1-4a1d-a086-0a5f165d5b5f?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/beacon-pines/9P4R2M0NRWNK"
     },
@@ -490,11 +469,11 @@
         "releaseDate": "22/11/2021",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/before-we-leave/9N360TZQZ0TR",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.64240.13938260246595322.6dab1a29-4d96-4a37-b22b-2baaeba55633.f371254b-cef0-4600-ad24-a5c03f04615a?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.64240.13938260246595322.6dab1a29-4d96-4a37-b22b-2baaeba55633.f371254b-cef0-4600-ad24-a5c03f04615a?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.29553.13938260246595322.6dab1a29-4d96-4a37-b22b-2baaeba55633.ca85b407-58d8-478e-9933-a2e851b86b9c?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/before-we-leave/9N360TZQZ0TR"
     },
@@ -509,11 +488,11 @@
         "releaseDate": "08/10/2020",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/ben-10-power-trip/9NJWFF2KHL6H",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.30849.13672727399820228.e1322d27-4961-46da-9c7b-c310d3e28cb1.90cdc8cc-0bdd-4b06-ba46-71549ba3bf46?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.30849.13672727399820228.e1322d27-4961-46da-9c7b-c310d3e28cb1.90cdc8cc-0bdd-4b06-ba46-71549ba3bf46?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.30224.13672727399820228.e1322d27-4961-46da-9c7b-c310d3e28cb1.27924fbb-bfd7-429d-96ac-7ad0ebbfeb5a?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/ben-10-uma-super-viagem/9NJWFF2KHL6H"
     },
@@ -527,11 +506,11 @@
         "releaseDate": "30/12/2799",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/besiege-console-game-preview/9PPFBQG81Q5J",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.45096.14326017138836689.0723eba4-7b1a-4eb0-8e6a-5c58708793ed.732b50ba-da04-4fbe-9368-64a7e03fcebd?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.45096.14326017138836689.0723eba4-7b1a-4eb0-8e6a-5c58708793ed.732b50ba-da04-4fbe-9368-64a7e03fcebd?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.56740.14326017138836689.ccbb306b-1919-48c6-833f-668c3ac421bc.26230173-5834-42f1-b4e2-886b60702820?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/besiege-console-game-preview/9PPFBQG81Q5J"
     },
@@ -545,12 +524,12 @@
         "releaseDate": "03/03/2019",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/black-desert/BTPDCJXNFSZL",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.55168.70463400880857175.d5efc868-ff4c-4751-bfbd-5f5b12ceed46.f8533b63-65dc-4100-9db6-a2b328bf176a?w=%i&h=%i",
-        "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.12267.70463400880857175.d5efc868-ff4c-4751-bfbd-5f5b12ceed46.900294d9-8c32-4663-be3f-233b82bc6e0c?h=%i&format=jpg",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.57274.70463400880857175.51ee65c4-60b3-46f6-87ac-1a8f5a1584ea.8853a725-0e75-48fe-885a-73ad441ee623?w=%i&format=jpg",
+        "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.44902.70463400880857175.51ee65c4-60b3-46f6-87ac-1a8f5a1584ea.2fef39d0-792c-4cbd-bc48-2d9436831fd2?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/black-desert/BTPDCJXNFSZL"
     },
     {
@@ -564,32 +543,13 @@
         "releaseDate": "24/03/2020",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/bleeding-edge/9NX6XGVJ0J3D",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.5290.14431087147384961.13dc1a18-3532-477b-b2d2-772256efc040.6fab8e78-8a3d-4b85-a5b1-33f32aeb8ea3?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.5290.14431087147384961.13dc1a18-3532-477b-b2d2-772256efc040.6fab8e78-8a3d-4b85-a5b1-33f32aeb8ea3?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.1277.14431087147384961.13dc1a18-3532-477b-b2d2-772256efc040.0a9d1479-3e71-4a22-ac8d-22b89141aba7?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/bleeding-edge/9NX6XGVJ0J3D"
-    },
-    {
-        "gameTitle": "Breathedge",
-        "gamePublisher": "HypeTrain Digital\u202c",
-        "gameDeveloper": "RedRuins Softworks",
-        "gameGenres": [
-            "A\u00e7\u00e3o e aventura",
-            "RPG"
-        ],
-        "releaseDate": "05/04/2021",
-        "extraGameProperties": {
-            "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
-        },
-        "xcloudUrl": "https://www.xbox.com/%s/play/games/breathedge/9NR7LV9PB9SD",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.64781.14387940932825223.b2bcb764-5659-4e3e-be75-fea7de3ead94.36290a14-76b1-4cda-b2b6-1991f2e95476?w=%i&h=%i",
-        "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.33682.14387940932825223.37633fb2-606d-4d0c-a1d2-87cd28b6a2ce.61b72a2b-5fc2-4e4e-b64a-c1e458f76e9f?h=%i&format=jpg",
-        "storeUrl": "https://www.xbox.com/games/store/breathedge/9NR7LV9PB9SD"
     },
     {
         "gameTitle": "Bridge Constructor Portal",
@@ -602,11 +562,11 @@
         "releaseDate": "27/02/2018",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/bridge-constructor-portal/BNRX1DN6GXM6",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.53942.68088896991488711.7d62a8af-1aa7-44bf-a425-105cabf5c97f.6aaec0f6-8abc-4ed7-a0dc-4ba047115e76?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.53942.68088896991488711.7d62a8af-1aa7-44bf-a425-105cabf5c97f.6aaec0f6-8abc-4ed7-a0dc-4ba047115e76?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.43524.68088896991488711.7d62a8af-1aa7-44bf-a425-105cabf5c97f.92eef38e-7a3d-42fa-b1c9-d21c1e4f01de?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/bridge-constructor-portal/BNRX1DN6GXM6"
     },
@@ -620,11 +580,11 @@
         "releaseDate": "22/06/2017",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/broken-age/BRT1K9FV4LRR",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.11626.69320940561073110.189571f5-bf61-4250-851f-3d627dfcdc29.bed721b9-7f8d-4800-ad0b-7a07807c0863?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.11626.69320940561073110.189571f5-bf61-4250-851f-3d627dfcdc29.bed721b9-7f8d-4800-ad0b-7a07807c0863?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.8857.69320940561073110.189571f5-bf61-4250-851f-3d627dfcdc29.26a2dcd6-c80f-45bf-977a-ead079284fe9?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/broken-age/BRT1K9FV4LRR"
     },
@@ -638,13 +598,32 @@
         "releaseDate": "28/04/2022",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/bugsnax/9P0FQ0XCV0LB",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.19620.14527663576451809.5be6f978-a9ed-42c5-8ee1-87dc4d947724.7e2ac7bd-0040-4c16-80e1-3a7cf1d566a7?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.19620.14527663576451809.5be6f978-a9ed-42c5-8ee1-87dc4d947724.7e2ac7bd-0040-4c16-80e1-3a7cf1d566a7?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.60740.14527663576451809.5be6f978-a9ed-42c5-8ee1-87dc4d947724.3c2a0c4e-eb2b-43e9-98d6-fff334b24473?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/bugsnax/9P0FQ0XCV0LB"
+    },
+    {
+        "gameTitle": "Chained Echoes",
+        "gamePublisher": "Deck13 Spotlight",
+        "gameDeveloper": "Matthias Linda",
+        "gameGenres": [
+            "RPG",
+            "A\u00e7\u00e3o e aventura"
+        ],
+        "releaseDate": "07/12/2022",
+        "extraGameProperties": {
+            "isInGamePass": true,
+            "controllerSupport": true,
+            "touchControllerSupport": false
+        },
+        "xcloudUrl": "https://www.xbox.com/%s/play/games/chained-echoes/9N1WWRPJ12FK",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.48881.13967692908687056.7893a3a8-746a-4e4f-aec4-16ec6b5ba396.ad337e09-7f04-45a9-b86b-eae8cc8c5067?w=%i&format=jpg",
+        "gameImageUrl": "https:AAAAIGZ0eXBhdmlmAAAAAGF2aWZtaWYxbWlhZk1BMUIAAADybWV0YQAAAAAAAAAoaGRscgAAAAAAAAAAcGljdAAAAAAAAAAAAAAAAGxpYmF2aWYAAAAADnBpdG0AAAAAAAEAAAAeaWxvYwAAAABEAAABAAEAAAABAAABGgAAEvMAAAAoaWluZgAAAAAAAQAAABppbmZlAgAAAAABAABhdjAxQ29sb3IAAAAAamlwcnAAAABLaXBjbwAAABRpc3BlAAAAAAAAA8AAAAIcAAAAEHBpeGkAAAAAAwgICAAAAAxhdjFDgQQMAAAAABNjb2xybmNseAABAAEAAYAAAAAXaXBtYQAAAAAAAAABAAEEAQKDBAAAEvttZGF0EgAKChkme/hvogICAwgy4iUQ3ADDDDEAgkD0uJloL/IWGSkZEGwVSjLSqtILBrBvhRKu/6G75+rbd8CBGI6qRciStZmCl66cJxpKxnVsXUEnyN2OBSyFEgAn/xbYB63xcP1qMhb4z6vBJAzl22YDQxowxfnTTsJvEc7jHtpQtRO8zXIkxH5FOSkKZgnLoocuWmsyLCeBMQ/Y2CfCcXFBGLAL5Od9gZwYKKyLD2DkdggKfyFlsS9eYivYaecJ6dPwWnfq/jtOpSva5kgf4m90Tbk18tvO36SZdWw9bcVSYZMbXpUICh1L8i4ikoY8o4EBlbTnA+dBj1gKRSm+ydBSv30aoFTZDhrS879mxefVyRJgymecRhfHObIgpnhmmih/EVR6b3ywnBHOPzV9DG7idFy3f3ev01QzSIiAoMO7sX+R9juuNPuo/T3GmNt5vXMctoZgStYZ6N8M/hqa7OFLHMSPVc0KsW88yMb9lCFAdl3dus/YG5dpyV356GImj5iuvb0AdBMG1KNqHSLTMlSb6W9jpbIimiNTSAr3A03SPa3tV0YoqN72wMto6z33nyD9Rxtjr+eV+xarO+0XzL6gGhvxYWvOOCnEIkEuF1LFQsqbFhxel2CXIGQJ685Y94pmXVjFIeAk9m7UlYRN4YsvYEqh3atflxyBVYG3LLJejL/l/2rIsSe1qtP3AQfAFbGjVSt42P6iQhIEM9Ft7Yl0vnW65zsbZcOILNQ93ecTby3bvvN00klgQqfiMajeH/Us5xuX+Fz+AAAXqja8OB1suZ3rnbL+Y6HRCga4bfyfZMnaCOp/FvrENDdWqciuBX2htYA+0wjgksZ9wQm9VdoPrN80Mw1PIlz0Z/zcqgSW2pH3pLUI7ZuoFvhNP3WEAw1csgbk0hmeAp4PLUNhz/M3/y0mWYF1I1y1grofKEHSZwxPg1wcB/kI/kVBt5OMrGlfcbmHogib+dQHwch/Lnzc1Uto4Kh3Kukat+ArF8vAnP2EO5Ko2jQYnC6/b/W00k9DogEiJQKBsv410VrDAiW/lCBAvqwJMD+f9PZcxc0/zrirz/5O+I2iREATjE1TD68QWnha05B1w+dWFkPplo5UcuKkTySgri3pdDmIbasDt3nYFiD58zL8O3/2TmbULUf+DfPNkBzGtUFbaL206BI0SyiiEcDLqMxY3GCBvl5jrPID6ctR9H/8xhRZ+p3sA2UgsQCYL7O/dxR57FIerX3l7QOpmkkVZLkc8Zq3bHCHrO2g+P8SV0gpdZNR7Jt6dUSPZQXsIWXInEwtha+SizSJRFIT82YJMwhQRM7RtrfjwwNt/disBRQZ4Fgt3yvbVf/gOXE9+a2Oj5UV/fs9/6R/sWA8ulTq2iPfuXWnVoYq8bmaeRgRg2mWOeotIxjl5Nvz7vbNjRwy2JGhwr7Tw4yf6A5UNNv1ODQXA4Lq92+fQ83EWPubkOw+ZsBN18Iw5Nawbgm0LmT0YByqkqSQQABykNU1MSqYcoGSGGi720FvEHyUinYPhlsmkef0Emj1kK7R08HmEflnpIGV/eMYgYnrxeA68qGGAU1VHWCsDd7nKAolXlOJJDecwr75P2AoaXRdIGJj9bCpFDjMIA69rlnBhsVoO3DQcA5EgwjMJiehDEJIi5ZDW4BKrPiVZhbEOKBFi9j1lHT0Q02NSsgoOcY6DUkkvCys7hvEWLHK603KbJgvLIix6SeTc3Z85diDrzyOPoB3FpwWrGwDYI6qtXMUMoWGHiqF8ndKfRMxapILkDKEwEl1TcLY9uYPTx7MBB1cYJEO26/TEyQrDom/t9AxzbvchhHn/s4cT6NIWKye5/Ax3/lQprrRSKHHhUXgZDHU8b55cGJvIOaPAAVU/OWSXvFJaJg7NAF59KLTs/QaQOY+XOkOrVckngjWfqptMTt7F14By9thqXTzB2yJw+26DbaRf8Q/AObcca5Bujoh9YH1SL3BlPElHhONTN78REUNH4JqSibgmMAaxDCTxjLLPOydVstEunniC6kySY6sZxtig3L885KY7seoxlxXtMEmvXSSaJfiV/r6Cgfe7IfRtWAxdpaCi3VGllDHD9H0b5VHvk3QfeTlXyzoXRoecZmoC/GmCplwCFBjViOuEVsacMcqtJYcF57qAAYOYSrXXKvRkG6mwvF1QbaLRHLANnBJ/OSFVOt93MNLafQ11pJEa2qfoSm71MOy7lpMgLQ5Qqf/DA9I16DUQVxqEAsu48k4kKxrsIHMObWEQmWX4wrk44aebulLGATBlxMMBKF1kkv3pd68mZcRezooop+fh7/9LPbUurm7s8dxk8kpvYqFUkIpF8sLiOnmyEB/NyBlurTgV/yQD+zA0BLm4nO6QHxWDrfV41ZQAYghz/AXP9ikxlvHM6Xv/LMjKc1isyxMTLSRwIa2IoxCaFv6eWsnxFFpFSAejBD4t16+EJuQchYOrQ6Vt/n/al/Z/onRaZ+e1/SSYCegCrlMzjpolzqZrCjX3vaGI+RuQ7f8u0Gnp8ij6KNnPPWJA0gPv5fSUav+D8Rhb4zPmIfYcmvr8z0apIXbNA9cO47fJNYJ6CqHXTukpV4YarR9Q48tUPUKbi5q1fuEE9gKSRXa3GW4sd9EiLsOST/CsR10ouAUXVmcao8FNXgzNw3fCpvdk4EwNbsAY4po7KSRNV57rVAqY6Q/2xPRI9uvqFIEQuepUwAQoQH98uNlXz6ZO9OnKc/GZSoKs94LN8IuyPMTrDjoILvBeH8Ob9B3BNq4OwgLDL4hKq4zwIQMVms4CJDk311zy37RkS5fxDLddfw1A0s1fOsVwr63QeyllZpq8vTWZZWZBNICezB1+v4QiS4KHaJJyHlnbVeJB1WrUmqvSYKMm3SV2c2XtQoNW5A4ccQI3LqT5v9I/Z3ATGDMov35j95IxCx9ArKxYPt+JlHxesbpLXYXijz8XlVmoBlI+veHUAX+qhPX2ktDz+yabpDom/avarmkPt3ve2es+zyA9MfMZd7nIximUgqZNEBoKhtq56jAzx5iwblt1AXVaME1qdSgrFNREt+7TRInJ7VkzYeSDiH6i0dKe+tTgxejF6CZE5IU8KYYZABhY3kC/oaybwH1+ahxKLz3+FDUZH/XP2vjY8DIhq4dVuBJpHvadH2mE7nrVHsITPfdqtqpBd6fFPRqXlW+QuD0lRCa8ocnNqpdhSIqoC9SqdrwLtQIqAbj7AYNVhNp9HnJd5BSBdSskuCG/SBGVLeh+Mbb05+E9oU0VQb2DJNKUm5wsW/wR9B/JNSVej5stWVqomlHN+ZG7oL4kKM1ftyDqY/5/NoeDgpFSwyqsa1/M+IVnlK/jFmnBA0wxz5phnzmsCvFwO69Yw3o11fEw4/59zhO75WYX7AMrq3XGt8RL/kAKJzfChOYnxmJpe2YOKiU/MbxhKFxnqt4/aA8nGjOz80PBaFx1B/BqBriBmg1Cdvdtt668/GQufmcALI5esAobu0QPFaT9mWtbYUlxPfp1vP9XraiyWL2OQ897rcjBBBgDo6iw5NJjFF+kzx9UvZEzNF1ZEvYaksTNzP94HXgx6IukDGf5MKwUsubgmn0ozatMNqi1ECQnsf1xkmnTT/wa0i48JJeCf1QBps2b88aw4ZMwq8OEbFqngpuqq/cUvQkP8mX84ABfcoEWjDdPaKkrEquOXbDf/7wddVo7JgKZvcdXFhtmp5mSLXUal9hTDVvcpFjxL111GCryDjLkzajV3N0mO5T1feP1XPIPeIbvX/Dm4LSSEhBgq8WcmviCbHhkVZcYZAR0DeCfaGH4gkTKS3u2tGZWEFVMQDhqm/fZRNroLa7mrd62bJkZnyMUwsDOxUnCu0H0pA3DgQLsj79aYMgzBDGbJIIHl79PFzRULrJWaUP7Hr2LRBCgXXVNY7/q+kZ5/4uh+epdFlaeQk1bewxjJjVFLNYGYJV6u+wb8wHLjIdykYIiRWrgvy45GK0iOGVD7aCHVc1rlLTrrrUF8qFclPi1liqnTRhRs8fC87i+tjteCSlOH1hijdkyFyEg9QY7wedQ8cnz1hAa47MLpDBH/418seOjYm2NJ6HQSu4PA1uggd3OXMRp2nAMvxGwnTWFZ1yoauZeUKwlu8UoOOwzzJK+9RcjhcN1cTo8vjq73jW0y9aJKSnmT2lQ8HtR0rKJovkgOkHS3uM25OTTxX5owx32w8N+rZnjaCIiOqrPRr95v2BW/0FTgjZjAklwz9vycjH4d/GeKW0HOthccqLQsFoUUFOpwrRcXElWOnzRm+4N+XmbSZe+XtQ23W7ywh6uER+nWl9/24Fc0bPSNaraju7EJR9Ro8E0QPcq2M9vPOECihAVI8T12a4T92OpPk0F7jq749ITIEWqxZdHiJGwkkKI86TNGag5tlT23B6YRyCMUNeShBT0hYUkOrxTTxXrMI+gtNfWTKTxc7oUDATM/E4qE8MgqFOkaCc+oEPXaheSjXKes+31+pe9Hda3u2ORvx5vM9Ds0CMd7cCl1QsyeORBAgheisWLkPtGdowkL2KsX42BH7sCb4a6x/RtJHAY581BcUJrbeBq7o7I+YVpIcQtP004H06AqLmCedddfHcySVl5FAUtxLRszgJJjuL9hxLZvKPTjL3db5PuFJYG+oI0t9IqBBd3AtCX00xiqtWEajQE548rm5MLFR9dwGAEjRGmyBVnOZDBId1TiLyymuqCrilcYJ3bz7xGR8HGgxVrRiT44NNGIprOkQv9kb3Fy8ZllXFMa8h7rFC3qVg2M3p6mVCOMGNVBML5kyXyLQ7CNbgQDVc9ep49XcP+Ij2uKORHUZ3SfDJZd57oR0NNwA5nzNOLOc+wlwYAaRSOHKIKh9UM5RdqZy5lU2kNWOwfovvoReYNWm6P80s3/r8PQ/n3MutbsEGJ2mWBSslGdo+JH6pYd2hg/rlISngXndT0GwzocFRcmjddpXY67OV0sUaTepGzWr3ntujW0/IJRC1Zej0SXDaiR+e9VyE7rgTuoU2gEiU0N5Lqbr5tZuqx8TGXs3cQLyZpC6wH+LdyTF4J0fmDlIBphe7r5IDCRBG8eOXuZRXGSoGPYaOmA2PUJefh7fVflc0LG36i5MQmF/KI7fTxavg+8/kH4gIh3S40X5V0sPxsNKPfNKJwKE2RPVXIqHzzWyPqEqwAI8PZZb1RrnI9nzlDH5UF3tIH4Cibmn0iifDFXW96ZT5fE57MAXFk90gfVIGCfg4AuR4aM5j0gr/LCPd3N6BDUGN1NelVsHfjf3J+sdlBhSHN31bcMDLqLXz8dGrKRAK/MWOhF2OhmanABLLp6+pDkzNItsgH08ZyyictMPUQuHIG+bBQlF53b0fbgQIZ5Q4O72zfCMDEz55qAIvc0NBuJIZumsUxUe7Dk0LLqjzZdfMivzdNmBJpATZOf72RZOHaUHehpecqOLXIk83Vsn0u77qIiJDsIXz45stg1ApnELGWM0VEJvaK1cD2WSJ2n8U/Phe9ynHcCNTjeSblB41b5icDZw0TNmU3QKtNovfZ8UUwgMNsbgxh+UCxhDYwfn3tfMk+iRRHn9pCougsMx/+0ungeJkxnZD5Z1Ux9G1vuTO6b0AeFnuNUoLpuo2K+Zu9RkI1rBfFFosSzJkk/G3REuZHMPQ5/WghwR0T848P3BbNsEJQWXao/PdtGXVN1OTuauMJVZFwSX98ndPmSQIbnB/ATIeKecx0+HLq7uxCzEFkmD3Cc+g4+jYg9YwBCyveCxRcOeDh5Xk5S18jBMbM2oDvLR9pKgEo1kaG4FJeH9vIVQbniQcqemdr86ZG8MzXlyZjfU8+rFrYToSRpCxV217GlWcf1tJEicM9IoMr2OxW254PlBgMfrHJc89wfmzHhs5+Bs82zEl8OiwGTh0GgxCDrhZ/z6RRywPG2aG4BcsGo6RGrp0ggzt8UtJSfvtpWcIq8iiKVcwTRzBW/UB534GohOljBPEQ+3z5sR7CpyW/aUCTbLtvBgg32osefXBOh9+KVhJI4dSM5OqIie2ohUk1l9wFEE3csezdgrydGTzeejGTbARd0Vlg8+5aa8Pjp52qR3SAtKrMYhV4pnRVKQNj5Q+cG9SCQ9mgSEjSHIVn7QAEFsnqvuMcEbfq/kcuT/zW7TLvJ4ttp8VsABhQBIss2uO2Sr8uzBnfcVGSvQJOux2uKF+tESgB9uFNQ6dNnr4UXGAa/FVoA+BWavJEsUOtafDzsuvypNyhqsN2xdaGxSYF8W/oI9AWcfrT8uxEoKGRWG+A8OkI2e0eq5RAudLh6rrlLh780d8TxP58UhGod6pOBKroGpmVj3ST9geZ67UfueS+bLv/Pu5Fhpv2/F4F3ZSzgJxIFnMZhuqmzEpCo0ezxMEQfO0TQuvQijElCxc9l0dJz1hAqslxGSKpjS7JnoGha7MHEvczLnl0d4hu+6gN2eIC8nGKS0oV8u5x/oZP6QpriEmZfPI9am/mQ2%iB",
+        "storeUrl": "https://www.xbox.com/games/store/chained-echoes/9N1WWRPJ12FK"
     },
     {
         "gameTitle": "Chinatown Detective Agency",
@@ -657,11 +636,11 @@
         "releaseDate": "07/04/2022",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/chinatown-detective-agency/9NV2VTVG0L31",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.32647.14407039492580836.0ee1fbde-13a0-4676-975c-913f27fd0ac6.5402bc40-0e5f-434f-8cc2-a738028aac3c?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.32647.14407039492580836.0ee1fbde-13a0-4676-975c-913f27fd0ac6.5402bc40-0e5f-434f-8cc2-a738028aac3c?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.42184.14407039492580836.0ee1fbde-13a0-4676-975c-913f27fd0ac6.0b6393da-0bb6-4e42-bf18-548d6f7a15cb?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/chinatown-detective-agency/9NV2VTVG0L31"
     },
@@ -676,12 +655,12 @@
         "releaseDate": "08/06/2021",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/chivalry-2/9N7CJX93ZGWN",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.61947.14071745200459129.81e3e86f-3ab4-4027-b9a1-81f595fcb505.fc2487e4-7785-4a73-b2ad-b94aa01a7e7f?w=%i&h=%i",
-        "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.56595.14071745200459129.81e3e86f-3ab4-4027-b9a1-81f595fcb505.bcc44c15-cee0-4c07-a92c-766beb8fb174?h=%i&format=jpg",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.35087.14071745200459129.07c29b7a-2fca-4fc4-a736-377002b90238.684d4f75-6d3f-46a9-b11e-1403b952ba02?w=%i&format=jpg",
+        "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.56970.14071745200459129.07c29b7a-2fca-4fc4-a736-377002b90238.aa168bc4-5607-46fc-ac53-1b07bbb49659?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/chivalry-2/9N7CJX93ZGWN"
     },
     {
@@ -695,11 +674,11 @@
         "releaseDate": "03/12/2021",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/chorus/9NN1Z8LHMFBV",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.19672.13751787478651765.747d9b13-75e6-4c34-a196-72624dc19de6.c2d9f22b-a5f5-4802-997c-7a5b2780895d?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.19672.13751787478651765.747d9b13-75e6-4c34-a196-72624dc19de6.c2d9f22b-a5f5-4802-997c-7a5b2780895d?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.57673.13751787478651765.747d9b13-75e6-4c34-a196-72624dc19de6.82444fe5-dcf8-40d1-bbeb-d51c254f00f5?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/chorus/9NN1Z8LHMFBV"
     },
@@ -713,11 +692,11 @@
         "releaseDate": "20/04/2017",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/cities-skylines---xbox-one-edition/C4GH8N6ZXG5L",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.42716.66617542682682743.811213f2-2c45-4145-973d-fe3e3774b196.c2dab488-7382-45d1-bf6c-6b8be6e3fd96?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.42716.66617542682682743.811213f2-2c45-4145-973d-fe3e3774b196.c2dab488-7382-45d1-bf6c-6b8be6e3fd96?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.59972.66617542682682743.811213f2-2c45-4145-973d-fe3e3774b196.2eb7da78-667d-41a9-b63f-f3f7a8d077c7?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/cities-skylines---xbox-one-edition/C4GH8N6ZXG5L"
     },
@@ -732,16 +711,16 @@
         "releaseDate": "05/05/2022",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/citizen-sleeper/9N6F97F9WGL0",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.55562.14019812399166283.86c56d8c-9235-45b0-85dd-dc9647631d6e.d1c98280-ac63-4f01-85ed-41e58c8fac35?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.55562.14019812399166283.86c56d8c-9235-45b0-85dd-dc9647631d6e.d1c98280-ac63-4f01-85ed-41e58c8fac35?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.15989.14019812399166283.86c56d8c-9235-45b0-85dd-dc9647631d6e.e8fa765b-6271-464c-ade7-54a3a44b004a?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/citizen-sleeper/9N6F97F9WGL0"
     },
     {
-        "gameTitle": "ClusterTruck",
+        "gameTitle": "Clustertruck",
         "gamePublisher": "tinyBuild",
         "gameDeveloper": "Landfall Games",
         "gameGenres": [
@@ -751,11 +730,11 @@
         "releaseDate": "27/10/2016",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/clustertruck/BX4J85JZNGXQ",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.11196.63460736466173537.43accb13-0658-4cb9-a3a9-2dd4b18ae15e.c12756d4-a28f-46d2-89d0-43593731f0d5?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.11196.63460736466173537.43accb13-0658-4cb9-a3a9-2dd4b18ae15e.c12756d4-a28f-46d2-89d0-43593731f0d5?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.32391.63460736466173537.43accb13-0658-4cb9-a3a9-2dd4b18ae15e.430f7951-125b-49ac-867b-8d7f482656c4?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/clustertruck/BX4J85JZNGXQ"
     },
@@ -770,11 +749,11 @@
         "releaseDate": "31/01/2020",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/coffee-talk/9N17CM38WNN8",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.30354.13910765112993759.85e2446b-e867-4d17-a642-a74c828870ce.c92e92ee-4550-424d-9389-a717815bd19f?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.30354.13910765112993759.85e2446b-e867-4d17-a642-a74c828870ce.c92e92ee-4550-424d-9389-a717815bd19f?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.28099.13910765112993759.85e2446b-e867-4d17-a642-a74c828870ce.1983b447-eff5-420a-9403-1b29145df76b?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/coffee-talk/9N17CM38WNN8"
     },
@@ -788,11 +767,11 @@
         "releaseDate": "29/08/2022",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/commandos-3---hd-remaster/9N1NBJNDD08J",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.10518.13897860358759559.772dd4c1-b1a6-4046-9b09-a4b441fe30aa.f56556c8-28de-4893-a4f4-59694207b18d?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.10518.13897860358759559.772dd4c1-b1a6-4046-9b09-a4b441fe30aa.f56556c8-28de-4893-a4f4-59694207b18d?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.37079.13897860358759559.316014c3-437b-4952-8fa8-f9088cd54b42.47709cf6-b301-4f26-b121-95ef69985843?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/commandos-3---hd-remaster/9N1NBJNDD08J"
     },
@@ -806,11 +785,11 @@
         "releaseDate": "07/05/2018",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/conan-exiles/C2X6ZCNKN2WR",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.44164.69492393318249993.eb0b8c74-1474-48d0-b663-4ec3bebca223.d1386244-7094-4e00-bff5-1aceb0260ec1?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.44164.69492393318249993.eb0b8c74-1474-48d0-b663-4ec3bebca223.d1386244-7094-4e00-bff5-1aceb0260ec1?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.58248.69492393318249993.eb0b8c74-1474-48d0-b663-4ec3bebca223.64a67385-b146-458c-b7a2-bf359de3fe60?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/conan-exiles/BS46X64QCJ5J"
     },
@@ -824,11 +803,11 @@
         "releaseDate": "25/06/2014",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/contrast/BSLTQT4L0RLV",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.19374.69833471246794389.8c89db73-09ce-4d32-a517-3dd3f2acf25f.d80b8b92-815d-4eed-a529-c7ba2376e8bf?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.19374.69833471246794389.8c89db73-09ce-4d32-a517-3dd3f2acf25f.d80b8b92-815d-4eed-a529-c7ba2376e8bf?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.43400.69833471246794389.8c89db73-09ce-4d32-a517-3dd3f2acf25f.320dba27-86d4-4e1f-8098-18e0cf93b3e7?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/contrast/BSLTQT4L0RLV"
     },
@@ -842,11 +821,11 @@
         "releaseDate": "14/08/2020",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/cooking-simulator/9N3DKKRHSJBT",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.40773.13934302625463282.ce885e17-8e35-4fa6-951c-1f7e58c35e4f.d2b59c71-aed1-4d55-b09f-70e66bdac381?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.40773.13934302625463282.ce885e17-8e35-4fa6-951c-1f7e58c35e4f.d2b59c71-aed1-4d55-b09f-70e66bdac381?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.32115.13934302625463282.ce885e17-8e35-4fa6-951c-1f7e58c35e4f.aedd415c-053d-49a0-a707-3aba18aa2a4f?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/cooking-simulator/9N3DKKRHSJBT"
     },
@@ -861,11 +840,11 @@
         "releaseDate": "19/10/2010",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/costume-quest/BR74RLMH966K",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.18636.69532389726997442.230b98e2-1f17-47ab-9d5a-06afb771f0de.57d2c274-ba74-4d0a-a98f-24a4ca808a82?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.18636.69532389726997442.230b98e2-1f17-47ab-9d5a-06afb771f0de.57d2c274-ba74-4d0a-a98f-24a4ca808a82?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.47121.69532389726997442.230b98e2-1f17-47ab-9d5a-06afb771f0de.a4b185ec-6d05-4391-9919-046299c7651b?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/costume-quest/BR74RLMH966K"
     },
@@ -879,11 +858,11 @@
         "releaseDate": "15/02/2019",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/crackdown-3/9NXR6469DM2P",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.63949.14494915233617130.8bc2d647-9563-4ed3-9081-f4a771cfa3a6.6504c19a-15a5-40a6-9231-343598749956?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.63949.14494915233617130.8bc2d647-9563-4ed3-9081-f4a771cfa3a6.6504c19a-15a5-40a6-9231-343598749956?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.7524.14494915233617130.8bc2d647-9563-4ed3-9081-f4a771cfa3a6.a1bdb61c-5265-420e-a5d0-307940ca5f9f?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/crackdown-3/9NXR6469DM2P"
     },
@@ -897,11 +876,11 @@
         "releaseDate": "01/12/2021",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/cricket-22/9NWNX54ZMT1K",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.1551.14445715000850412.83840d24-19b4-4894-8f10-770047ae8042.fb44a74d-b647-4469-8076-46dc98b8c5d8?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.1551.14445715000850412.83840d24-19b4-4894-8f10-770047ae8042.fb44a74d-b647-4469-8076-46dc98b8c5d8?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.23609.14445715000850412.0b9795f4-c737-4dce-a154-a9d7431b8c65.53a1b7f8-5e0e-4349-b9d0-e64095e2934b?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/cricket-22/9NWNX54ZMT1K"
     },
@@ -915,11 +894,11 @@
         "releaseDate": "10/11/2003",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/crimson-skies-high-road-to-revenge/C4B8XR1LCXR5",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.48725.66564363245508968.4a646a68-6736-4349-ad5c-933bc20f715a.b8eb2ce7-ae0f-4e67-8135-ff43f6e74122?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.48725.66564363245508968.4a646a68-6736-4349-ad5c-933bc20f715a.b8eb2ce7-ae0f-4e67-8135-ff43f6e74122?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.18821.66564363245508968.4a646a68-6736-4349-ad5c-933bc20f715a.39a7b0fa-23ae-4928-925c-001eaa5d4dc3?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/crimson-skies-high-road-to-revenge/C4B8XR1LCXR5"
     },
@@ -933,11 +912,11 @@
         "releaseDate": "29/12/9998",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/crossfirex-operation-catalyst/9N5Q1VBD1ZWZ",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.27725.14033786176609620.31182a97-1d0c-40d0-8327-f1d454daeeaa.f29602cc-3292-41e1-8d36-67e405056c36?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.27725.14033786176609620.31182a97-1d0c-40d0-8327-f1d454daeeaa.f29602cc-3292-41e1-8d36-67e405056c36?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.51388.14033786176609620.31182a97-1d0c-40d0-8327-f1d454daeeaa.c3bd776c-b9c7-401f-8cb5-7fb5e3150075?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/crossfirex-operation-catalyst/9N5Q1VBD1ZWZ"
     },
@@ -952,11 +931,11 @@
         "releaseDate": "06/09/2021",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/crown-trick/9NGCPXQG3NLZ",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.23005.13647911596394486.628fddf1-5978-4b67-a823-e73a2ca794eb.3bd24da1-c7fe-4d16-bf4c-e882c4b02355?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.23005.13647911596394486.628fddf1-5978-4b67-a823-e73a2ca794eb.3bd24da1-c7fe-4d16-bf4c-e882c4b02355?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.4611.13647911596394486.d3982cea-7cad-416c-bd96-c919d4e1778f.a1d19137-13d2-4082-8f37-d131385fcc15?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/crown-trick/9NGCPXQG3NLZ"
     },
@@ -971,11 +950,11 @@
         "releaseDate": "29/03/2022",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/crusader-kings-iii/9MZ8RZSD0NFQ",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.30214.13879075332331019.da1cf290-ab60-45cb-891e-71702235fa65.f0c38059-800f-4c03-ba16-7594f08ea6a4?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.30214.13879075332331019.da1cf290-ab60-45cb-891e-71702235fa65.f0c38059-800f-4c03-ba16-7594f08ea6a4?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.61473.13879075332331019.da1cf290-ab60-45cb-891e-71702235fa65.18daa26b-682e-491f-8e1c-87533a00b5b3?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/crusader-kings-iii/9MZ8RZSD0NFQ"
     },
@@ -990,11 +969,11 @@
         "releaseDate": "15/07/2022",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/dc-league-of-super-pets-the-adventures-of-krypto-a/9NP1G0T8JDMR",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.14291.13727697462687238.ee76eff3-10ea-49a9-b873-90c81b9db9f0.f9fcc017-5bf0-4d89-84be-0fabc9746dcc?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.14291.13727697462687238.ee76eff3-10ea-49a9-b873-90c81b9db9f0.f9fcc017-5bf0-4d89-84be-0fabc9746dcc?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.34631.13727697462687238.ee76eff3-10ea-49a9-b873-90c81b9db9f0.1abd2a13-907a-4bb9-b31e-6bc1c9f7420f?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/dc-liga-dos-superpets-as-aventuras-de-krypto-e-ace/9NP1G0T8JDMR"
     },
@@ -1009,31 +988,13 @@
         "releaseDate": "20/09/2022",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/deathloop/9P5Z4530318L",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.5858.14634955238674857.649b7ff9-0dfc-4951-9b65-c5d815215da6.90208516-ba3b-47a9-a130-ef94cf860f5b?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.5858.14634955238674857.649b7ff9-0dfc-4951-9b65-c5d815215da6.90208516-ba3b-47a9-a130-ef94cf860f5b?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.26641.14634955238674857.649b7ff9-0dfc-4951-9b65-c5d815215da6.bacdd878-0313-4c58-9434-459afd7cf535?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/deathloop/9P5Z4530318L"
-    },
-    {
-        "gameTitle": "DEEEER Simulator: Um Jogo de Veado Corriqueiro do Cotidiano",
-        "gamePublisher": "PLAYISM",
-        "gameDeveloper": "Gibier Games",
-        "gameGenres": [
-            "A\u00e7\u00e3o e aventura"
-        ],
-        "releaseDate": "23/11/2021",
-        "extraGameProperties": {
-            "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
-        },
-        "xcloudUrl": "https://www.xbox.com/%s/play/games/deeeer-simulator-your-average-everyday-deer-game/9NNBPBM2F60W",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.38917.13741589124987756.7ce40278-4e54-4838-8822-3f597ec873af.cea3e300-6115-4b9a-b1e8-20db029b012f?w=%i&h=%i",
-        "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.56497.13741589124987756.7ce40278-4e54-4838-8822-3f597ec873af.fbc7f58d-e125-476a-ada8-c1533d63cc67?h=%i&format=jpg",
-        "storeUrl": "https://www.xbox.com/games/store/deeeer-simulator-um-jogo-de-veado-corriqueiro-do-c/9NNBPBM2F60W"
     },
     {
         "gameTitle": "DIRT 5",
@@ -1046,11 +1007,11 @@
         "releaseDate": "05/11/2020",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/dirt-5/9PJGM0T0827V",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.57632.14216887906907763.b5352caa-b411-460d-acb5-a427d0106d4b.6eee667c-5c9b-4fec-a070-261c100702cf?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.57632.14216887906907763.b5352caa-b411-460d-acb5-a427d0106d4b.6eee667c-5c9b-4fec-a070-261c100702cf?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.43063.14216887906907763.f147e9dc-f500-4358-91e8-68c6906fcc18.7a1b601c-5b4b-4b4a-a95c-28309baf099d?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/dirt-5/9PJGM0T0827V"
     },
@@ -1064,11 +1025,11 @@
         "releaseDate": "06/07/2022",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/djmax-respect-v/9P544PGZXC0P",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.28299.14576235444726870.3e2b0155-ca8d-4075-bc12-04165b7144c1.54dbb62c-89d0-43d8-b39d-baef555b54ab?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.28299.14576235444726870.3e2b0155-ca8d-4075-bc12-04165b7144c1.54dbb62c-89d0-43d8-b39d-baef555b54ab?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.43739.14576235444726870.3e2b0155-ca8d-4075-bc12-04165b7144c1.0463db0d-2611-4b62-9622-423dfb90e56b?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/djmax-respect-v/9P544PGZXC0P"
     },
@@ -1082,11 +1043,11 @@
         "releaseDate": "12/05/2016",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/doom/C3QH42WRGM3R",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.9537.66773763610413114.5c7115ed-b566-4d24-80ce-7027cb5b7c3e.26ccbdb5-174d-4f5d-8e51-9fbb56b09362?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.9537.66773763610413114.5c7115ed-b566-4d24-80ce-7027cb5b7c3e.26ccbdb5-174d-4f5d-8e51-9fbb56b09362?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.16825.66773763610413114.5c7115ed-b566-4d24-80ce-7027cb5b7c3e.7d2fc072-886d-446e-9f37-e71d442ae729?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/doom/C3QH42WRGM3R"
     },
@@ -1100,11 +1061,11 @@
         "releaseDate": "26/07/2019",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/doom-1993/9PLZPHBNHTMF",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.50165.14303655336501012.2beb08d9-395e-453b-b5e3-0d4ac24d9d15.3b2510cc-2384-4f0d-b261-cdaa80b16ccc?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.50165.14303655336501012.2beb08d9-395e-453b-b5e3-0d4ac24d9d15.3b2510cc-2384-4f0d-b261-cdaa80b16ccc?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.55563.14303655336501012.2beb08d9-395e-453b-b5e3-0d4ac24d9d15.f9a0e430-b546-45f8-85f1-1d2b90bb84d5?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/doom-1993/9PLZPHBNHTMF"
     },
@@ -1118,11 +1079,11 @@
         "releaseDate": "26/07/2019",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/doom-3/9NSL68D814GC",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.60652.14361385044335696.50e1eb97-e01a-40d6-839c-7082e07b25b3.470b5116-eb1e-4467-b925-703e307c0297?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.60652.14361385044335696.50e1eb97-e01a-40d6-839c-7082e07b25b3.470b5116-eb1e-4467-b925-703e307c0297?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.49616.14361385044335696.d9d52dee-3885-40bf-b48d-1934a8ba4324.d811c242-92de-477f-ac23-26449e84d684?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/doom-3/9NSL68D814GC"
     },
@@ -1137,11 +1098,11 @@
         "releaseDate": "20/03/2020",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/doom-64/9MXND4PQLK3W",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.46055.13886780434132750.58497d0f-3220-4d2f-a7ff-96dcff27bc5f.4aac1ddb-3d94-42df-a4bb-cb2dc420c7fb?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.46055.13886780434132750.58497d0f-3220-4d2f-a7ff-96dcff27bc5f.4aac1ddb-3d94-42df-a4bb-cb2dc420c7fb?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.62661.13886780434132750.58497d0f-3220-4d2f-a7ff-96dcff27bc5f.b73dcad6-d181-4cb9-91b3-2fcc2fd53852?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/doom-64/9MXND4PQLK3W"
     },
@@ -1155,11 +1116,11 @@
         "releaseDate": "20/03/2020",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/doom-eternal-standard-edition/9P5S26314HWQ",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.447.64234556958324114.f920cec9-b4fb-47f4-bbac-667ed8bb82e6.361bfcfd-dedc-4575-aa66-5a5f145a6b75?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.447.64234556958324114.f920cec9-b4fb-47f4-bbac-667ed8bb82e6.361bfcfd-dedc-4575-aa66-5a5f145a6b75?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.19006.64234556958324114.f920cec9-b4fb-47f4-bbac-667ed8bb82e6.e900b072-1d04-450b-8c81-93034fd6d39d?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/doom-eternal-standard-edition/9P5S26314HWQ"
     },
@@ -1173,11 +1134,11 @@
         "releaseDate": "26/07/2019",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/doom-ii-classic/9PLT62LRF9V7",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.57570.14311014949668376.25a6b443-a817-4a82-b4ec-852ef07ef120.7bb2e6db-047f-41cd-8d76-a78b5abe499b?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.57570.14311014949668376.25a6b443-a817-4a82-b4ec-852ef07ef120.7bb2e6db-047f-41cd-8d76-a78b5abe499b?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.58135.14311014949668376.25a6b443-a817-4a82-b4ec-852ef07ef120.0d06fd3d-ecb0-4ca0-8f2e-39e8a66ff4cf?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/doom-ii-classic/9PLT62LRF9V7"
     },
@@ -1191,11 +1152,11 @@
         "releaseDate": "25/01/2018",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/dragon-ball-fighterz/BZRK5C951KK7",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.53484.63836873768130262.f1f140d8-4fff-49c3-b318-36fca1cd7343.9bf0edf7-3a14-43bb-8d05-f53de189ece1?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.53484.63836873768130262.f1f140d8-4fff-49c3-b318-36fca1cd7343.9bf0edf7-3a14-43bb-8d05-f53de189ece1?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.62697.63836873768130262.f1f140d8-4fff-49c3-b318-36fca1cd7343.72c15fe8-8104-42f2-891b-a7aaa5d01c94?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/dragon-ball-fighterz/BZRK5C951KK7"
     },
@@ -1209,31 +1170,13 @@
         "releaseDate": "03/05/2021",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/dragon-quest-builders-2/9PFD00CZJ35V",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.53352.14202829435326027.d8e6d286-7438-43e7-999e-60378c648621.3518a5b8-26cf-4ed6-9016-068170d6cc70?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.53352.14202829435326027.d8e6d286-7438-43e7-999e-60378c648621.3518a5b8-26cf-4ed6-9016-068170d6cc70?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.49678.14202829435326027.d8e6d286-7438-43e7-999e-60378c648621.857d322c-2a3b-4a53-8073-2798687358d0?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/dragon-quest-builders-2/9PFD00CZJ35V"
-    },
-    {
-        "gameTitle": "DRAGON QUEST\u00ae XI S: Echoes of an Elusive Age\u2122 - Definitive Edition",
-        "gamePublisher": "SQUARE ENIX",
-        "gameDeveloper": "SQUARE ENIX",
-        "gameGenres": [
-            "RPG"
-        ],
-        "releaseDate": "03/12/2020",
-        "extraGameProperties": {
-            "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
-        },
-        "xcloudUrl": "https://www.xbox.com/%s/play/games/dragon-quest-xi-s-echoes-of-an-elusive-age---defin/9PBDC0XZ8TXK",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.50295.14125332336761514.8bb2a8ee-0291-4012-97d8-2e92be70a6ac.90afa133-6034-4c81-a6fd-e7767c438a72?w=%i&h=%i",
-        "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.16758.14125332336761514.8bb2a8ee-0291-4012-97d8-2e92be70a6ac.ff120ed5-2604-4ccc-ae66-bfbdce1112a9?h=%i&format=jpg",
-        "storeUrl": "https://www.xbox.com/games/store/dragon-quest-xi-s-echoes-of-an-elusive-age---defin/9PBDC0XZ8TXK"
     },
     {
         "gameTitle": "Danganronpa 2: Goodbye Despair Anniversary Edition",
@@ -1245,11 +1188,11 @@
         "releaseDate": "09/05/2022",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/danganronpa-2-goodbye-despair-anniversary-edition/9N27NM3BT3ML",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.41493.13957199450175735.1b230d7b-e0f6-46ef-852d-a872d636bf5d.5fbadc7a-49da-46b7-95d1-7ce0ed4cc101?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.41493.13957199450175735.1b230d7b-e0f6-46ef-852d-a872d636bf5d.5fbadc7a-49da-46b7-95d1-7ce0ed4cc101?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.54728.13957199450175735.1b230d7b-e0f6-46ef-852d-a872d636bf5d.06f68b2e-19cd-4123-afb5-bdf7a6841d83?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/danganronpa-2-goodbye-despair-anniversary-edition/9N27NM3BT3ML"
     },
@@ -1263,11 +1206,11 @@
         "releaseDate": "15/09/2022",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/danganronpa-v3-killing-harmony-anniversary-edition/9PMM6V93MRKW",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.25192.14291162525435146.863a4856-e937-4f6f-81c8-efcb52a1546f.68e9c078-c1a4-42e7-b8f8-4a0450cea363?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.25192.14291162525435146.863a4856-e937-4f6f-81c8-efcb52a1546f.68e9c078-c1a4-42e7-b8f8-4a0450cea363?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.32432.14291162525435146.863a4856-e937-4f6f-81c8-efcb52a1546f.ceab6fa9-0e52-4eb3-9890-3909f6095705?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/danganronpa-v3-killing-harmony-anniversary-edition/9PMM6V93MRKW"
     },
@@ -1281,11 +1224,11 @@
         "releaseDate": "17/01/2022",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/danganronpa-trigger-happy-havoc-anniversary-editio/9N07T7TGP6JG",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.15823.13926025773515961.65bfebc1-45c3-4c37-966f-35fa549dd9ce.6a2914c5-b1d3-4fa0-a102-91fa7ffb6445?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.15823.13926025773515961.65bfebc1-45c3-4c37-966f-35fa549dd9ce.6a2914c5-b1d3-4fa0-a102-91fa7ffb6445?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.64573.13926025773515961.65bfebc1-45c3-4c37-966f-35fa549dd9ce.f60569b4-8d5f-4885-8e8c-a6a7e3a259e8?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/danganronpa-trigger-happy-havoc-anniversary-editio/9N07T7TGP6JG"
     },
@@ -1300,11 +1243,11 @@
         "releaseDate": "26/03/2019",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/dayz/BSR9NLHVF1KL",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.47889.69886306496288395.9ec42146-6037-4440-b5c7-3a44e5213cc3.633ff3eb-8f2a-4567-ac38-ab688a819736?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.47889.69886306496288395.9ec42146-6037-4440-b5c7-3a44e5213cc3.633ff3eb-8f2a-4567-ac38-ab688a819736?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.25654.69886306496288395.9ec42146-6037-4440-b5c7-3a44e5213cc3.b6ce47f8-80fe-4ea3-8d04-2cfa13905bca?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/dayz/BSR9NLHVF1KL"
     },
@@ -1319,11 +1262,11 @@
         "releaseDate": "06/08/2018",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/dead-cells/BQSCNS1T8PHQ",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.28912.13719691835186674.79361d33-7a18-4554-8a50-66b60d3712e6.c6a6a941-82c2-43b3-ba3e-c53428df00a6?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.28912.13719691835186674.79361d33-7a18-4554-8a50-66b60d3712e6.c6a6a941-82c2-43b3-ba3e-c53428df00a6?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.40300.13719691835186674.79361d33-7a18-4554-8a50-66b60d3712e6.d7bd4952-930d-4f5e-863b-67bb13f5199d?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/dead-cells/BQSCNS1T8PHQ"
     },
@@ -1337,11 +1280,11 @@
         "releaseDate": "02/08/2010",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/dead-space-2008/BRJLJ6RPLQTJ",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.9607.69768431406041041.e1386476-b377-413b-9457-1f5559dbb168.345050eb-2861-4fc1-9bdb-e7dcc7965eea?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.9607.69768431406041041.e1386476-b377-413b-9457-1f5559dbb168.345050eb-2861-4fc1-9bdb-e7dcc7965eea?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.19172.69768431406041041.e1386476-b377-413b-9457-1f5559dbb168.e1b07f40-7e45-4cd3-bc9b-5a8ce23b2995?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/dead-space-2008/BRJLJ6RPLQTJ"
     },
@@ -1356,11 +1299,11 @@
         "releaseDate": "19/06/2017",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/dead-by-daylight/C0N22P73QZ60",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.51458.64366672042187759.733004ed-c696-44cf-98cc-30eddf2375a8.33981a4c-a34b-4492-b81f-8695c017496b?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.51458.64366672042187759.733004ed-c696-44cf-98cc-30eddf2375a8.33981a4c-a34b-4492-b81f-8695c017496b?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.13651.64366672042187759.733004ed-c696-44cf-98cc-30eddf2375a8.6bdb69ed-d0ef-4157-b2df-7ea97d3b1c4a?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/dead-by-daylight/C0N22P73QZ60"
     },
@@ -1374,11 +1317,11 @@
         "releaseDate": "20/07/2021",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/death's-door-%5Bxbox%5D/9NDZ7NXFF622",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.46691.13605204887272793.456e749a-524b-4372-bb98-1e7f5fac0947.55c39ef5-1120-4c74-a37d-79ee51e2e5cb?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.46691.13605204887272793.456e749a-524b-4372-bb98-1e7f5fac0947.55c39ef5-1120-4c74-a37d-79ee51e2e5cb?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.50661.13605204887272793.456e749a-524b-4372-bb98-1e7f5fac0947.7d789bd8-b026-4a71-90a6-8907f81bec8f?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/death's-door-[xbox]/9NDZ7NXFF622"
     },
@@ -1392,12 +1335,12 @@
         "releaseDate": "13/05/2020",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/deep-rock-galactic/9NHFVWX1V7QJ",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.49248.13626568325427111.ffcf66bb-5b9a-4ac5-8d67-8ba8f37e12a9.6b66bb30-355f-43ac-aab3-1256b15578c1?w=%i&h=%i",
-        "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.46973.13626568325427111.ffcf66bb-5b9a-4ac5-8d67-8ba8f37e12a9.807da6ce-caac-485b-8b45-7441326873e2?h=%i&format=jpg",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.26993.13626568325427111.10c3cd94-9222-478a-b93e-3ab79133a2ee.1ced74c2-4745-4eb3-825b-c9747caa60b8?w=%i&format=jpg",
+        "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.53393.13626568325427111.10c3cd94-9222-478a-b93e-3ab79133a2ee.67681eff-71a1-4485-bc07-d8d357531c50?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/deep-rock-galactic/9NHFVWX1V7QJ"
     },
     {
@@ -1411,11 +1354,11 @@
         "releaseDate": "06/05/2019",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/descenders/C37XBX7DCBZ0",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.22806.65934155925401073.332e7c23-85a6-43b3-a586-2f915e27a737.f779bef0-3997-4eba-94f0-7b88eb3a74b4?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.22806.65934155925401073.332e7c23-85a6-43b3-a586-2f915e27a737.f779bef0-3997-4eba-94f0-7b88eb3a74b4?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.28922.65934155925401073.cdde9208-c05c-4015-852b-3c48d95ed87b.ef83fe76-7f8b-4be5-9520-14df3444ffe2?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/descenders/C37XBX7DCBZ0"
     },
@@ -1430,11 +1373,11 @@
         "releaseDate": "29/09/2022",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/despot's-game/9P5ZDVMCJMFD",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.54530.14634731171917513.ee44ea98-341d-42e8-b67a-c2a4254a08a0.3a8876e7-694c-40d5-8efc-0264051414e8?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.54530.14634731171917513.ee44ea98-341d-42e8-b67a-c2a4254a08a0.3a8876e7-694c-40d5-8efc-0264051414e8?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.13399.14634731171917513.ee44ea98-341d-42e8-b67a-c2a4254a08a0.4239454b-8c5a-4424-b410-2039ca63a84c?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/despot's-game/9P5ZDVMCJMFD"
     },
@@ -1448,11 +1391,11 @@
         "releaseDate": "28/07/2020",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/destroy-all-humans/C2GMBPMTHDDK",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.24055.65473857825187654.ebbe44de-afda-462d-a514-ec44f41ee0aa.811f648d-1bf8-4b89-bb26-f7c413b42cd2?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.24055.65473857825187654.ebbe44de-afda-462d-a514-ec44f41ee0aa.811f648d-1bf8-4b89-bb26-f7c413b42cd2?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.13114.65473857825187654.ebbe44de-afda-462d-a514-ec44f41ee0aa.5c5ab897-d46d-4ee5-99ef-b0fa7ea16b5a?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/destroy-all-humans/C2GMBPMTHDDK"
     },
@@ -1467,11 +1410,11 @@
         "releaseDate": "10/11/2021",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/dicey-dungeons/9PC4C9NLP3ZD",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.27476.14176621031001937.302a4c64-8f4d-435d-8b6d-fcd963ff70e6.59fb0946-5c13-432a-9412-eb3814a2f376?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.27476.14176621031001937.302a4c64-8f4d-435d-8b6d-fcd963ff70e6.59fb0946-5c13-432a-9412-eb3814a2f376?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.9181.14176621031001937.302a4c64-8f4d-435d-8b6d-fcd963ff70e6.54c59da3-1a2f-4a01-9c28-55eb2436f75b?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/dicey-dungeons/9PC4C9NLP3ZD"
     },
@@ -1485,11 +1428,11 @@
         "releaseDate": "06/06/2022",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/disc-room/9PK5G9HBH6NH",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.9672.14269183666889184.e7870fdb-6f27-4590-86e7-17bc5ea2e4f6.e86925a8-1747-4813-a958-cf37a4277380?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.9672.14269183666889184.e7870fdb-6f27-4590-86e7-17bc5ea2e4f6.e86925a8-1747-4813-a958-cf37a4277380?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.18149.14269183666889184.e7870fdb-6f27-4590-86e7-17bc5ea2e4f6.0f5379dd-2d0b-4d1d-88f5-d4f77257ecf2?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/disc-room/9PK5G9HBH6NH"
     },
@@ -1503,11 +1446,11 @@
         "releaseDate": "10/11/2016",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/dishonored-2/BSZM480TSWGP",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.10911.70043444627144466.07c9aa2e-cabd-4198-941b-534a009f5e9b.cf528c6d-d4d8-4c06-ab21-dafe846ff6ac?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.10911.70043444627144466.07c9aa2e-cabd-4198-941b-534a009f5e9b.cf528c6d-d4d8-4c06-ab21-dafe846ff6ac?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.26992.70043444627144466.07c9aa2e-cabd-4198-941b-534a009f5e9b.f287ebaa-4d8e-465e-83d0-be5eaeb48869?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/dishonored-2/BSZM480TSWGP"
     },
@@ -1521,11 +1464,11 @@
         "releaseDate": "24/08/2015",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/dishonored-definitive-edition/C299QVC2BSJF",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.59694.65371894126242138.81c958b9-c96e-47c6-81fa-93c549ea1a80.2a213c60-376c-4924-add8-4429c6ef6357?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.59694.65371894126242138.81c958b9-c96e-47c6-81fa-93c549ea1a80.2a213c60-376c-4924-add8-4429c6ef6357?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.62889.65371894126242138.81c958b9-c96e-47c6-81fa-93c549ea1a80.cfca16ac-2517-4803-8038-67afcf2f5c84?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/dishonored-definitive-edition/C299QVC2BSJF"
     },
@@ -1539,11 +1482,11 @@
         "releaseDate": "14/09/2017",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/dishonored-death-of-the-outsider/C5F2XDQPPJKZ",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.45510.67180938922431908.a2c2d9ea-42a1-4ddc-bf74-8b91562769cf.29da272d-e2a1-4934-b9e9-563227373143?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.45510.67180938922431908.a2c2d9ea-42a1-4ddc-bf74-8b91562769cf.29da272d-e2a1-4934-b9e9-563227373143?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.32468.67180938922431908.a2c2d9ea-42a1-4ddc-bf74-8b91562769cf.3188aa6f-4a83-4577-8fcd-7dc2e6fbdc58?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/dishonored-death-of-the-outsider/C5F2XDQPPJKZ"
     },
@@ -1558,11 +1501,11 @@
         "releaseDate": "06/09/2022",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/disney-dreamlight-valley/9NSF0BGH8D86",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.62890.14365104417622257.42e17a74-81d1-4e35-8c38-a935ba30ef21.80948ce2-63b2-49df-9e97-4ab247b81f10?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.62890.14365104417622257.42e17a74-81d1-4e35-8c38-a935ba30ef21.80948ce2-63b2-49df-9e97-4ab247b81f10?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.55487.14365104417622257.42e17a74-81d1-4e35-8c38-a935ba30ef21.539426cb-c927-4051-88ef-dcbc2f931108?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/disney-dreamlight-valley/9NSF0BGH8D86"
     },
@@ -1576,11 +1519,11 @@
         "releaseDate": "30/10/2017",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/disneyland-adventures/9N6Z8DQXSQWH",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.38755.14005003576279990.0e4e6d67-22da-40e5-b520-630686e37930.302b7455-6387-4813-8177-5e2844e8b61f?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.38755.14005003576279990.0e4e6d67-22da-40e5-b520-630686e37930.302b7455-6387-4813-8177-5e2844e8b61f?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.50242.14005003576279990.10d0c7c3-8f62-48ea-8cca-677d7c7b92ee.03fda480-425e-4847-8cb4-0eea39387d41?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/disneyland-adventures/9N6Z8DQXSQWH"
     },
@@ -1595,11 +1538,11 @@
         "releaseDate": "17/12/2018",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/donut-county/9N6V2181GHLM",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.60906.14011542784181932.80ac6320-df7b-4be6-9355-e9083a5d2063.06135ea0-0572-4ed3-b5a2-e0a158e3144d?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.60906.14011542784181932.80ac6320-df7b-4be6-9355-e9083a5d2063.06135ea0-0572-4ed3-b5a2-e0a158e3144d?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.29308.14011542784181932.80ac6320-df7b-4be6-9355-e9083a5d2063.7453474c-587b-4024-ad6d-a785d30d7fc4?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/donut-county/9N6V2181GHLM"
     },
@@ -1613,11 +1556,11 @@
         "releaseDate": "01/11/2010",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/dragon-age-origins/BS9SX4Q6XJRF",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.25088.70226594498231256.17116041-5bab-4f35-9bd5-63b5de669a3f.3076712f-3ab7-4813-a935-b1f954d8e904?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.25088.70226594498231256.17116041-5bab-4f35-9bd5-63b5de669a3f.3076712f-3ab7-4813-a935-b1f954d8e904?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.57159.70226594498231256.17116041-5bab-4f35-9bd5-63b5de669a3f.c2663062-0738-4072-a075-da4babd7d1c6?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/dragon-age-origins/BS9SX4Q6XJRF"
     },
@@ -1631,11 +1574,11 @@
         "releaseDate": "17/11/2014",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/dragon-age-inquisition/C47GZZBMR5WG",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.1094.66474211586744867.e24f67e1-7195-4bf7-9758-84e7723c0673.ba5ac0c8-e5fb-42c8-a648-a81b5fe939ff?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.1094.66474211586744867.e24f67e1-7195-4bf7-9758-84e7723c0673.ba5ac0c8-e5fb-42c8-a648-a81b5fe939ff?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.31941.66474211586744867.e24f67e1-7195-4bf7-9758-84e7723c0673.5da54656-795f-4c70-ab92-dfeeb3d87584?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/dragon-age-inquisition/C47GZZBMR5WG"
     },
@@ -1650,13 +1593,32 @@
         "releaseDate": "02/02/2022",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/dreamscaper/9NB7FZ2GV5N1",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.64147.13522425449027354.d30e2029-af7b-42b5-9597-24dab387b2b5.5f9b306d-bb7b-4f07-99c2-c27d94d455e0?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.64147.13522425449027354.d30e2029-af7b-42b5-9597-24dab387b2b5.5f9b306d-bb7b-4f07-99c2-c27d94d455e0?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.3404.13522425449027354.d30e2029-af7b-42b5-9597-24dab387b2b5.df171986-ad35-4dd9-8c9d-ae969f9d0bca?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/dreamscaper/9NB7FZ2GV5N1"
+    },
+    {
+        "gameTitle": "Eastward",
+        "gamePublisher": "Chucklefish",
+        "gameDeveloper": "Pixpil",
+        "gameGenres": [
+            "A\u00e7\u00e3o e aventura",
+            "RPG"
+        ],
+        "releaseDate": "01/12/2022",
+        "extraGameProperties": {
+            "isInGamePass": true,
+            "controllerSupport": true,
+            "touchControllerSupport": false
+        },
+        "xcloudUrl": "https://www.xbox.com/%s/play/games/eastward/9NSBX56ZNP7X",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.35706.14370759136672533.dd01dbaf-ca58-4330-83f4-614a98d999d1.3ef6b81b-a103-40d7-b005-269e2785956f?w=%i&format=jpg",
+        "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.16050.14370759136672533.dd01dbaf-ca58-4330-83f4-614a98d999d1.8910e0af-a260-434d-8ebd-3d61c602a123?h=%i&format=jpg",
+        "storeUrl": "https://www.xbox.com/games/store/eastward/9NSBX56ZNP7X"
     },
     {
         "gameTitle": "Edge of Eternity",
@@ -1669,11 +1631,11 @@
         "releaseDate": "10/02/2022",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/edge-of-eternity/9P934697Z4W4",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.16694.14080357279144129.c9fd9598-f310-4593-b38e-50d9b36a791b.62fb47a3-8d76-4ba5-9ff0-ac8098649cf6?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.16694.14080357279144129.c9fd9598-f310-4593-b38e-50d9b36a791b.62fb47a3-8d76-4ba5-9ff0-ac8098649cf6?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.7456.14080357279144129.c9fd9598-f310-4593-b38e-50d9b36a791b.faef1c9f-3525-4837-af07-734ee1d320fc?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/edge-of-eternity/9P934697Z4W4"
     },
@@ -1687,11 +1649,11 @@
         "releaseDate": "10/05/2022",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/eiyuden-chronicle-rising/9NMD6VV08WGF",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.9020.13694306682751994.5bc2fdaa-7629-4489-9dcb-d5aacee2da36.ef9b1a83-12c4-429e-87b9-6fed1ad5f431?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.9020.13694306682751994.5bc2fdaa-7629-4489-9dcb-d5aacee2da36.ef9b1a83-12c4-429e-87b9-6fed1ad5f431?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.29866.13694306682751994.5bc2fdaa-7629-4489-9dcb-d5aacee2da36.e9703b5f-50a3-4e55-84b3-5dece2758fce?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/eiyuden-chronicle-rising/9NMD6VV08WGF"
     },
@@ -1706,11 +1668,11 @@
         "releaseDate": "22/09/2021",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/embr/9P9XS9D0LBPV",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.10405.14134157626658703.ad01f8b0-d5c5-49de-b137-27e100034590.7e8ae4c0-4206-430c-90d0-8db4c8edb68f?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.10405.14134157626658703.ad01f8b0-d5c5-49de-b137-27e100034590.7e8ae4c0-4206-430c-90d0-8db4c8edb68f?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.17698.14134157626658703.ad01f8b0-d5c5-49de-b137-27e100034590.8f3f9e8f-6f4b-4852-a61d-d99afbdee520?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/embr/9P9XS9D0LBPV"
     },
@@ -1725,11 +1687,11 @@
         "releaseDate": "01/12/2020",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/empire-of-sin/9NN7NF8N5Q5C",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.64796.13747976611115190.63973483-7da5-48ba-bb81-accb70ec340f.354443e8-3b01-47c1-a33e-ac487f8a8cc1?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.64796.13747976611115190.63973483-7da5-48ba-bb81-accb70ec340f.354443e8-3b01-47c1-a33e-ac487f8a8cc1?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.58631.13747976611115190.63973483-7da5-48ba-bb81-accb70ec340f.2dca3670-5de7-4cd5-b7e1-8366a382d658?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/empire-of-sin/9NN7NF8N5Q5C"
     },
@@ -1744,11 +1706,11 @@
         "releaseDate": "14/07/2022",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/escape-academy/9P3NT9H51RMR",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.27583.14539026038241714.21a192f1-dd13-4371-b3d3-bd3b46c94f1c.e22769c9-5f6a-4b3b-86db-23b45314350c?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.27583.14539026038241714.21a192f1-dd13-4371-b3d3-bd3b46c94f1c.e22769c9-5f6a-4b3b-86db-23b45314350c?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.31067.14539026038241714.286d01b5-ac41-42cd-bdbf-9a9417a8ea9e.8129cf30-417e-40c8-97b0-8bd019d86750?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/escape-academy/9P3NT9H51RMR"
     },
@@ -1762,11 +1724,11 @@
         "releaseDate": "29/11/2021",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/evil-genius-2-world-domination/9NPC5398SCQ6",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.56773.13725970033936449.25aa6307-fa1b-4241-9ec3-abc63be55bac.e27edbe4-2824-44ff-8139-77965b9581a9?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.56773.13725970033936449.25aa6307-fa1b-4241-9ec3-abc63be55bac.e27edbe4-2824-44ff-8139-77965b9581a9?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.54106.13725970033936449.25aa6307-fa1b-4241-9ec3-abc63be55bac.e3f4d345-5a07-4993-912c-0c5f901696bd?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/evil-genius-2-world-domination/9NPC5398SCQ6"
     },
@@ -1781,11 +1743,11 @@
         "releaseDate": "11/10/2022",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/eville/9PC12991NZ5N",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.31296.14112988465880137.944f8dc0-63f1-4f15-96aa-cab88a628053.65e7f8f4-3625-4a09-8aa7-fead27a7806f?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.31296.14112988465880137.944f8dc0-63f1-4f15-96aa-cab88a628053.65e7f8f4-3625-4a09-8aa7-fead27a7806f?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.19828.14112988465880137.944f8dc0-63f1-4f15-96aa-cab88a628053.3baaa95c-7788-4c73-aef5-b1cd1bd840b6?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/eville/9PC12991NZ5N"
     },
@@ -1800,11 +1762,11 @@
         "releaseDate": "18/11/2021",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/exo-one/9NJG36MFVR1L",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.8995.13681719632931019.3fadfa10-4988-4e93-8972-339883dea36a.c9fad8d9-ff5b-4d8a-bbfe-dce0089e073a?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.8995.13681719632931019.3fadfa10-4988-4e93-8972-339883dea36a.c9fad8d9-ff5b-4d8a-bbfe-dce0089e073a?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.55217.13681719632931019.3fadfa10-4988-4e93-8972-339883dea36a.9476cad4-4500-4000-b639-0213f5000d36?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/exo-one/9NJG36MFVR1L"
     },
@@ -1819,11 +1781,11 @@
         "releaseDate": "15/07/2021",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/f1-2021/9N6J02VPG635",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.37657.14013748203655664.db785774-47f3-45ce-bd9e-3b1596621222.efc40178-0102-49ea-ab22-2dd4e3fad20c?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.37657.14013748203655664.db785774-47f3-45ce-bd9e-3b1596621222.efc40178-0102-49ea-ab22-2dd4e3fad20c?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.12136.14013748203655664.db785774-47f3-45ce-bd9e-3b1596621222.48395430-82be-4045-a174-cecbbda965e7?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/f1-2021/9N6J02VPG635"
     },
@@ -1837,11 +1799,11 @@
         "releaseDate": "01/03/2022",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/far-changing-tides/9N29VZ9LRNNQ",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.47853.13955748726326945.7931fe0b-e479-493c-a5eb-ac7155d10f18.aa8c6226-657f-4c1a-a5cf-8266f83ac9f8?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.47853.13955748726326945.7931fe0b-e479-493c-a5eb-ac7155d10f18.aa8c6226-657f-4c1a-a5cf-8266f83ac9f8?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.24352.13955748726326945.7931fe0b-e479-493c-a5eb-ac7155d10f18.732c24be-6c7e-48f2-a379-adf8dd0ec728?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/far-changing-tides/9N29VZ9LRNNQ"
     },
@@ -1855,11 +1817,11 @@
         "releaseDate": "15/10/2018",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/for-honor-marching-fire-edition/C4CBF3FHHCND",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.27398.66538969761564623.2ff1d4ba-a932-4a84-a4e7-5e3810d6d336.f36638ca-65e0-4b99-97be-f665c0ab94bd?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.27398.66538969761564623.2ff1d4ba-a932-4a84-a4e7-5e3810d6d336.f36638ca-65e0-4b99-97be-f665c0ab94bd?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.31135.66538969761564623.2ff1d4ba-a932-4a84-a4e7-5e3810d6d336.ba7e9799-5dec-4d08-af90-911ffa2168fc?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/for-honor-marching-fire-edition/C4CBF3FHHCND"
     },
@@ -1873,11 +1835,11 @@
         "releaseDate": "28/01/2014",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/fable-anniversary/C2Q32JM0BPZL",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.44376.66175927222580475.7f09fde8-a46b-4c45-8584-a5e3090f8190.12d67f03-4a2b-4967-982a-9980a185e1b1?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.44376.66175927222580475.7f09fde8-a46b-4c45-8584-a5e3090f8190.12d67f03-4a2b-4967-982a-9980a185e1b1?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.11896.66175927222580475.7f09fde8-a46b-4c45-8584-a5e3090f8190.58c0cf42-378d-471e-941b-cb63488c7de5?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/fable-anniversary/C2Q32JM0BPZL"
     },
@@ -1891,11 +1853,11 @@
         "releaseDate": "05/04/2010",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/fable-ii/C2WKJJ9F5936",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.12706.66274487452813675.86971dec-0f03-42bb-b657-322859f064f4.5b8be489-c377-4439-a4a5-5564da9a165b?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.12706.66274487452813675.86971dec-0f03-42bb-b657-322859f064f4.5b8be489-c377-4439-a4a5-5564da9a165b?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.60848.66274487452813675.86971dec-0f03-42bb-b657-322859f064f4.bbf884e7-eb3c-4826-816f-027108f500b6?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/fable-ii/C2WKJJ9F5936"
     },
@@ -1910,32 +1872,13 @@
         "releaseDate": "16/05/2011",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/fable-iii/BR46KM4D5B9L",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.49206.68952782261614407.207517f2-cff8-4d40-84e1-b44139d6e70b.77a300c7-676b-4530-ae94-7438be18bd8e?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.49206.68952782261614407.207517f2-cff8-4d40-84e1-b44139d6e70b.77a300c7-676b-4530-ae94-7438be18bd8e?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.57973.68952782261614407.207517f2-cff8-4d40-84e1-b44139d6e70b.bf178dec-cd3e-446d-a76b-a9c9208d4680?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/fable-iii/BR46KM4D5B9L"
-    },
-    {
-        "gameTitle": "Fae Tactics",
-        "gamePublisher": "Humble Games",
-        "gameDeveloper": "Endlessfluff Games",
-        "gameGenres": [
-            "RPG",
-            "Estrat\u00e9gia"
-        ],
-        "releaseDate": "17/11/2021",
-        "extraGameProperties": {
-            "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
-        },
-        "xcloudUrl": "https://www.xbox.com/%s/play/games/fae-tactics/9PL4HXW1H502",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.51450.14249741584182441.fad329ed-ca88-42b0-bfd3-dde8d09e0e7e.93a46ddb-0ae0-4f3a-a8a4-5d37a73292a4?w=%i&h=%i",
-        "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.24869.14249741584182441.fad329ed-ca88-42b0-bfd3-dde8d09e0e7e.2fa38c0b-0a87-46bb-9fdd-0c54bfb694a2?h=%i&format=jpg",
-        "storeUrl": "https://www.xbox.com/games/store/fae-tactics/9PL4HXW1H502"
     },
     {
         "gameTitle": "Fallout 3",
@@ -1947,11 +1890,11 @@
         "releaseDate": "01/03/2010",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/fallout-3/C29HQ887KH4B",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.38961.65367730044127425.992bf426-3c9a-450f-a792-7946f7138dee.98e9a605-2163-4484-8952-1d8de0909b8f?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.38961.65367730044127425.992bf426-3c9a-450f-a792-7946f7138dee.98e9a605-2163-4484-8952-1d8de0909b8f?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.16997.65367730044127425.992bf426-3c9a-450f-a792-7946f7138dee.b7e225d6-9bb7-4a0d-94dc-47bde86b6693?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/fallout-3/C29HQ887KH4B"
     },
@@ -1965,11 +1908,11 @@
         "releaseDate": "09/11/2015",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/fallout-4/C3KLDKZBHNCZ",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.54862.66091604408099736.4cc75ea1-c6a0-40ec-b7f9-7fdb8da581b2.5e94fe90-d2f9-4757-8c2c-b97408d79876?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.54862.66091604408099736.4cc75ea1-c6a0-40ec-b7f9-7fdb8da581b2.5e94fe90-d2f9-4757-8c2c-b97408d79876?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.31046.66091604408099736.4cc75ea1-c6a0-40ec-b7f9-7fdb8da581b2.a57d4b8c-5413-4da4-ac55-d22e67c07969?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/fallout-4/C3KLDKZBHNCZ"
     },
@@ -1983,12 +1926,12 @@
         "releaseDate": "13/11/2018",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/fallout-76/BS6WJ2L56B10",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.39914.70143269474194625.d1eeac92-8fe9-443b-af8f-40450ce537a2.86eb483a-50d8-4b2b-94e1-ecf09ce5e590?w=%i&h=%i",
-        "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.58496.70143269474194625.d1eeac92-8fe9-443b-af8f-40450ce537a2.03fe8575-ee40-4cef-98cb-bb6896afa3b1?h=%i&format=jpg",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.48360.70143269474194625.4be198a3-f44c-41ff-810a-3e6a3612462e.dbf5a6ab-1179-4c8d-a905-a84a6159d6e6?w=%i&format=jpg",
+        "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.34390.70143269474194625.4be198a3-f44c-41ff-810a-3e6a3612462e.1cf2266a-f991-4130-ba59-43d9b9a07aa3?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/fallout-76/BS6WJ2L56B10"
     },
     {
@@ -2002,11 +1945,11 @@
         "releaseDate": "18/04/2011",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/fallout-new-vegas/BX3JNK07Z6QK",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.54716.63413868670389858.a909f79f-bf9a-495a-9565-6895806c3525.3405026a-8882-4e5a-8f49-41ccbc9686a3?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.54716.63413868670389858.a909f79f-bf9a-495a-9565-6895806c3525.3405026a-8882-4e5a-8f49-41ccbc9686a3?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.48990.63413868670389858.a909f79f-bf9a-495a-9565-6895806c3525.64c38aa8-fafc-4198-a7ec-629b5054e84e?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/fallout-new-vegas/BX3JNK07Z6QK"
     },
@@ -2020,11 +1963,11 @@
         "releaseDate": "26/03/2018",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/far-cry-5/BR7X7MVBBQKM",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.48705.69582963086497758.e1cff2e3-ddf1-42bf-930d-f380ad63f100.1eb992fd-461c-4edd-9e5e-b3fbb7a41044?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.48705.69582963086497758.e1cff2e3-ddf1-42bf-930d-f380ad63f100.1eb992fd-461c-4edd-9e5e-b3fbb7a41044?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.22845.69582963086497758.e1cff2e3-ddf1-42bf-930d-f380ad63f100.1ef04059-9768-4999-b495-f48a52290ae9?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/far-cry-5/BR7X7MVBBQKM"
     },
@@ -2038,31 +1981,13 @@
         "releaseDate": "22/11/2021",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/farming-simulator-22/9P6SRW1HVW9K",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.44229.14617846210383148.2692112c-5cf0-4f44-8fcf-72e45e75380c.cb519bf7-8b19-4e28-bd15-994c42ee2b26?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.44229.14617846210383148.2692112c-5cf0-4f44-8fcf-72e45e75380c.cb519bf7-8b19-4e28-bd15-994c42ee2b26?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.35136.14617846210383148.f5d1d30e-892f-4959-a5b8-f2ef506cf0ae.d40fe9db-42d7-4434-83be-bcbb42f685c3?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/farming-simulator-22/9P6SRW1HVW9K"
-    },
-    {
-        "gameTitle": "Firewatch",
-        "gamePublisher": "Campo Santo",
-        "gameDeveloper": "Campo Santo",
-        "gameGenres": [
-            "A\u00e7\u00e3o e aventura"
-        ],
-        "releaseDate": "20/09/2016",
-        "extraGameProperties": {
-            "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
-        },
-        "xcloudUrl": "https://www.xbox.com/%s/play/games/firewatch/BQQKG9H2STC0",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.40478.68688977722932617.c18986e0-354d-49e5-a689-33d52a7432cb.15d49e14-f3c9-4949-b807-62a02521442b?w=%i&h=%i",
-        "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.14501.68688977722932617.c18986e0-354d-49e5-a689-33d52a7432cb.4324e613-281f-4948-bd74-d17321615130?h=%i&format=jpg",
-        "storeUrl": "https://www.xbox.com/games/store/firewatch/BQQKG9H2STC0"
     },
     {
         "gameTitle": "Floppy Knights",
@@ -2075,11 +2000,11 @@
         "releaseDate": "23/05/2022",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/floppy-knights/9NLM4TTHCWSH",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.30829.13705007807700068.f8418398-1ad9-4e90-bf4e-8ce6aabbfbfa.df128ff9-1246-46b2-bbed-8e4c98445275?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.30829.13705007807700068.f8418398-1ad9-4e90-bf4e-8ce6aabbfbfa.df128ff9-1246-46b2-bbed-8e4c98445275?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.15574.13705007807700068.f8418398-1ad9-4e90-bf4e-8ce6aabbfbfa.edecefb3-678b-4d2d-8269-b2db60216c37?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/floppy-knights/9NLM4TTHCWSH"
     },
@@ -2094,11 +2019,11 @@
         "releaseDate": "15/07/2020",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/forager/9MV2S7Q5PHSW",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.54794.13796714672158376.aa1c19be-0d47-46ac-9fb3-74c8d6d9fdf8.aa68b619-7475-49d7-9f98-ea5020f22958?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.54794.13796714672158376.aa1c19be-0d47-46ac-9fb3-74c8d6d9fdf8.aa68b619-7475-49d7-9f98-ea5020f22958?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.39862.13796714672158376.aa1c19be-0d47-46ac-9fb3-74c8d6d9fdf8.450a5deb-8adb-4bb1-84ef-0af38f56c8ce?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/forager/9MV2S7Q5PHSW"
     },
@@ -2113,12 +2038,12 @@
         "releaseDate": "24/07/2017",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/fortnite/BT5P2X999VH2",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.59377.70702278257994163.852f160a-a678-4fa5-a9e3-fdeffeb7e7dd.44c6f6d7-4bb2-42ba-be35-984b29425077?w=%i&h=%i",
-        "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.39022.70702278257994163.852f160a-a678-4fa5-a9e3-fdeffeb7e7dd.71fff695-ed20-459a-a44d-2ce06684e9df?h=%i&format=jpg",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.28189.70702278257994163.c9dbdd20-b809-4871-bc3e-47ef1a02388b.474e786e-ed78-454d-9c41-a9edb473d607?w=%i&format=jpg",
+        "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.31.70702278257994163.c9dbdd20-b809-4871-bc3e-47ef1a02388b.dd360d2c-af1b-483e-a265-42d5b8067eca?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/fortnite/BT5P2X999VH2"
     },
     {
@@ -2131,11 +2056,11 @@
         "releaseDate": "02/10/2018",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/forza-horizon-4-standard-edition/9PNJXVCVWD4K",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.2050.14343301090572358.2000000000007864205.da7d6a7f-5e66-439b-82e9-e5c23f17f739?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.2050.14343301090572358.2000000000007864205.da7d6a7f-5e66-439b-82e9-e5c23f17f739?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.51635.14343301090572358.2000000000007864230.cb90c37a-b1b9-44bc-9387-cf6f398e06cd?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/forza-horizon-4-edi%C3%A7%C3%A3o-padr%C3%A3o/9PNJXVCVWD4K"
     },
@@ -2149,11 +2074,11 @@
         "releaseDate": "09/11/2021",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/forza-horizon-5-standard-edition/9NKX70BBCDRN",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.18975.13718773309227929.bebdcc0e-1ed5-4778-8732-f4ef65a2f445.125d6b3b-492f-4e5f-8037-7ade230c8224?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.18975.13718773309227929.bebdcc0e-1ed5-4778-8732-f4ef65a2f445.125d6b3b-492f-4e5f-8037-7ade230c8224?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.33953.13718773309227929.bebdcc0e-1ed5-4778-8732-f4ef65a2f445.9428b75f-2c08-4e70-9f95-281741b15341?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/forza-horizon-5-edi%C3%A7%C3%A3o-padr%C3%A3o/9NKX70BBCDRN"
     },
@@ -2168,11 +2093,11 @@
         "releaseDate": "11/10/2019",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/frostpunk-console-edition/9NP539LHJD8S",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.46316.13729671074412623.f72f7df4-e873-4e52-a4dc-651d0b3e8b0f.1625980c-0794-44fa-88d0-e00b37773b21?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.46316.13729671074412623.f72f7df4-e873-4e52-a4dc-651d0b3e8b0f.1625980c-0794-44fa-88d0-e00b37773b21?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.14473.13729671074412623.3c1853e8-a2eb-4ccb-b708-021e412d015c.2700e93a-8d11-4611-be92-9ef46597b880?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/frostpunk-console-edition/9NP539LHJD8S"
     },
@@ -2186,11 +2111,11 @@
         "releaseDate": "28/07/2021",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/fuga-melodies-of-steel/9NLX3GWW0HF1",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.41808.13703325884761588.f33ea47b-9cce-415c-a23e-066944821a2c.298c2f09-26eb-4529-a16c-e7b3c50c3def?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.41808.13703325884761588.f33ea47b-9cce-415c-a23e-066944821a2c.298c2f09-26eb-4529-a16c-e7b3c50c3def?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.37253.13703325884761588.f33ea47b-9cce-415c-a23e-066944821a2c.9f3dca0f-edf2-44a4-8c15-2266f7a59bc7?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/fuga-melodies-of-steel/9NLX3GWW0HF1"
     },
@@ -2204,11 +2129,11 @@
         "releaseDate": "22/09/2001",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/fuzion-frenzy/C2P985H1H42H",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.29460.65553901453292980.5f73bae7-0b93-4345-bf12-87df77ec6f05.2e554579-0c20-4b04-89a5-e6cbce60d4a0?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.29460.65553901453292980.5f73bae7-0b93-4345-bf12-87df77ec6f05.2e554579-0c20-4b04-89a5-e6cbce60d4a0?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.6987.65553901453292980.5f73bae7-0b93-4345-bf12-87df77ec6f05.67f3135c-8a07-43e3-9a1f-461408bddaf9?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/fuzion-frenzy/C2P985H1H42H"
     },
@@ -2222,11 +2147,11 @@
         "releaseDate": "26/03/2019",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/gang-beasts/BPQZT43FWD49",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.27333.68150164172276526.ddc374d7-ef5e-43b9-940a-bbc04440bb33.fa908ac2-c1a8-4d1b-9652-c977565a8111?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.27333.68150164172276526.ddc374d7-ef5e-43b9-940a-bbc04440bb33.fa908ac2-c1a8-4d1b-9652-c977565a8111?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.32163.68150164172276526.ddc374d7-ef5e-43b9-940a-bbc04440bb33.deaff9b9-d8af-4e35-9f45-75951fe60524?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/gang-beasts/BPQZT43FWD49"
     },
@@ -2241,11 +2166,11 @@
         "releaseDate": "11/07/2022",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/garden-story/9PP09MJRH2XD",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.59861.14334501706636147.97df104f-715b-4347-b111-98fa1cbd5f7c.c9ebf3de-6630-46e2-a5ba-612131822246?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.59861.14334501706636147.97df104f-715b-4347-b111-98fa1cbd5f7c.c9ebf3de-6630-46e2-a5ba-612131822246?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.37921.14334501706636147.97df104f-715b-4347-b111-98fa1cbd5f7c.0e810e17-6a1b-4890-ac7a-f3e1ad8213fb?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/garden-story/9PP09MJRH2XD"
     },
@@ -2259,11 +2184,11 @@
         "releaseDate": "14/12/2020",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/gears-5-game-of-the-year-edition/9P4KMR76PLLQ",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.9672.14591801423393397.e1044226-28d7-42f6-a357-7102f7d1a4b3.5554c17b-3189-46a1-93fb-2005d1d08e7e?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.9672.14591801423393397.e1044226-28d7-42f6-a357-7102f7d1a4b3.5554c17b-3189-46a1-93fb-2005d1d08e7e?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.26484.14591801423393397.e1044226-28d7-42f6-a357-7102f7d1a4b3.8adca5d4-cdf8-44b2-b453-98e567ad0264?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/edi%C3%A7%C3%A3o-gears-5---game-of-the-year/9P4KMR76PLLQ"
     },
@@ -2277,11 +2202,11 @@
         "releaseDate": "09/11/2020",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/gears-tactics/9NN3HCKW5TPC",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.2270.13750744755532010.7748d323-597f-440a-94e4-9c030198efa6.39a3aebc-6a07-4d8a-83e3-597bd117ff7b?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.2270.13750744755532010.7748d323-597f-440a-94e4-9c030198efa6.39a3aebc-6a07-4d8a-83e3-597bd117ff7b?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.14840.13750744755532010.7748d323-597f-440a-94e4-9c030198efa6.35089704-1d88-49c8-9cb6-cf15ce10a9a5?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/gears-tactics/9NN3HCKW5TPC"
     },
@@ -2295,11 +2220,11 @@
         "releaseDate": "11/10/2010",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/gears-of-war-2/C1SDBNRFXT1D",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.22422.65595136073047161.857e51a5-2b52-4c0e-8ac2-92b6b4609fc2.575238f4-dafa-47d8-a0b9-0ab665f39566?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.22422.65595136073047161.857e51a5-2b52-4c0e-8ac2-92b6b4609fc2.575238f4-dafa-47d8-a0b9-0ab665f39566?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.25609.65595136073047161.857e51a5-2b52-4c0e-8ac2-92b6b4609fc2.6df5069b-fe9a-436c-875c-9e14f0d754a1?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/gears-of-war-2/C1SDBNRFXT1D"
     },
@@ -2313,11 +2238,11 @@
         "releaseDate": "26/03/2012",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/gears-of-war-3/BPKDQSSFQ9WV",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.17664.68607194681373551.b4c09a44-be36-42d6-96c5-4a33b566becd.f0735af8-acef-4b7e-b40c-d0d2b622dd37?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.17664.68607194681373551.b4c09a44-be36-42d6-96c5-4a33b566becd.f0735af8-acef-4b7e-b40c-d0d2b622dd37?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.52315.68607194681373551.b4c09a44-be36-42d6-96c5-4a33b566becd.9199c63b-06f1-41b5-8118-c1d2373ee86a?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/gears-of-war-3/BPKDQSSFQ9WV"
     },
@@ -2331,11 +2256,11 @@
         "releaseDate": "11/10/2016",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/gears-of-war-4/9NBLGGH4PBBM",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.27107.13510798887356280.e9581154-ba55-457f-9b5f-4285b6036ba9.852cd1b9-b6db-430f-a640-b02d32c72c05?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.27107.13510798887356280.e9581154-ba55-457f-9b5f-4285b6036ba9.852cd1b9-b6db-430f-a640-b02d32c72c05?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.6102.13510798887356280.9398b0dd-2ecf-4973-9380-576d1d374a25.92d12017-af9a-41ae-b97a-8213710cdb49?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/gears-of-war-4/9NBLGGH4PBBM"
     },
@@ -2349,11 +2274,11 @@
         "releaseDate": "17/06/2013",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/gears-of-war-judgment/BSHMMGRP84N4",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.44244.70323071690757883.aa344172-c923-4b38-a055-9ce9a093bc86.0f5d2994-3b99-4968-9b8b-ccdff7d7612f?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.44244.70323071690757883.aa344172-c923-4b38-a055-9ce9a093bc86.0f5d2994-3b99-4968-9b8b-ccdff7d7612f?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.1787.70323071690757883.aa344172-c923-4b38-a055-9ce9a093bc86.4728b066-afb5-4b2a-bdc2-d91341663e15?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/gears-of-war-judgment/BSHMMGRP84N4"
     },
@@ -2367,18 +2292,18 @@
         "releaseDate": "24/08/2015",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/gears-of-war-ultimate-edition/BQT21VXFS52F",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.30935.68785176255228170.152a1029-d0c3-4d27-a42d-ecccb32aa4ca.dc750da7-3cda-4a73-9705-24b6c06e820d?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.30935.68785176255228170.152a1029-d0c3-4d27-a42d-ecccb32aa4ca.dc750da7-3cda-4a73-9705-24b6c06e820d?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.10153.68785176255228170.152a1029-d0c3-4d27-a42d-ecccb32aa4ca.12e2db46-e6be-4494-a43e-ccf2e701ed16?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/gears-of-war-ultimate-edition/BQT21VXFS52F"
     },
     {
         "gameTitle": "Generation Zero\u00ae",
-        "gamePublisher": "Systemic Reaction\u2122",
-        "gameDeveloper": "Systemic Reaction\u2122",
+        "gamePublisher": "Systemic Reaction",
+        "gameDeveloper": "Systemic Reaction",
         "gameGenres": [
             "A\u00e7\u00e3o e aventura",
             "Jogos de tiros"
@@ -2386,12 +2311,12 @@
         "releaseDate": "25/03/2019",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/generation-zero/C20WW4W29FQ1",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.26037.65743914527603622.c1e9cb1f-651a-4556-9033-7aa1173649f4.a99f23b6-999e-464f-95d9-fd4609a6b809?w=%i&h=%i",
-        "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.283.65743914527603622.c1e9cb1f-651a-4556-9033-7aa1173649f4.60c2569f-7adc-4b76-81ec-d4f43935573c?h=%i&format=jpg",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.5248.65743914527603622.b98c7b82-aeb0-44e7-8071-19a17867fd8c.23de469b-d409-404e-882b-54f1a741e3d5?w=%i&format=jpg",
+        "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.18399.65743914527603622.b98c7b82-aeb0-44e7-8071-19a17867fd8c.d4c19546-885f-4094-9e7b-35453dc31596?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/generation-zero/C20WW4W29FQ1"
     },
     {
@@ -2405,13 +2330,32 @@
         "releaseDate": "11/03/2021",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/genesis-noir/9PHK9D8CLQCG",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.47660.13844380730124915.b015e4f1-318e-475f-8d5a-24ea35c62b4c.c9ffcac7-cf41-4392-9a5c-164e93e0aa64?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.47660.13844380730124915.b015e4f1-318e-475f-8d5a-24ea35c62b4c.c9ffcac7-cf41-4392-9a5c-164e93e0aa64?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.22196.13844380730124915.b015e4f1-318e-475f-8d5a-24ea35c62b4c.338f029a-10a4-4847-9a2a-ff261bd1d26b?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/genesis-noir/9PHK9D8CLQCG"
+    },
+    {
+        "gameTitle": "Ghost Song",
+        "gamePublisher": "Humble Games",
+        "gameDeveloper": "Old Moon",
+        "gameGenres": [
+            "A\u00e7\u00e3o e aventura",
+            "RPG"
+        ],
+        "releaseDate": "03/11/2022",
+        "extraGameProperties": {
+            "isInGamePass": true,
+            "controllerSupport": true,
+            "touchControllerSupport": true
+        },
+        "xcloudUrl": "https://www.xbox.com/%s/play/games/ghost-song/9PJ2FC2LK9QD",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.55880.14220417113702203.f590cea6-e90b-47a0-b64b-b0f78f890cb5.dfdb8a23-f7a5-4289-8db5-94c57e288bb7?w=%i&format=jpg",
+        "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.50513.14220417113702203.f590cea6-e90b-47a0-b64b-b0f78f890cb5.2a97befa-4ec2-4f0e-aa97-6e7eb66ae933?h=%i&format=jpg",
+        "storeUrl": "https://www.xbox.com/games/store/ghost-song/9PJ2FC2LK9QD"
     },
     {
         "gameTitle": "Goat Simulator",
@@ -2423,13 +2367,32 @@
         "releaseDate": "16/04/2015",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/goat-simulator/BV0NM309K1TL",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.53467.70628353720390187.c5ec2284-1a6e-4ed0-a094-b54b14b8d466.186f50d1-55ce-4827-925f-6816154430d6?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.53467.70628353720390187.c5ec2284-1a6e-4ed0-a094-b54b14b8d466.186f50d1-55ce-4827-925f-6816154430d6?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.46116.70628353720390187.c5ec2284-1a6e-4ed0-a094-b54b14b8d466.f01d3b8d-41e1-42bc-b322-443ee5b1f390?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/goat-simulator/BV0NM309K1TL"
+    },
+    {
+        "gameTitle": "Golf With Your Friends",
+        "gamePublisher": "Team17",
+        "gameDeveloper": "Blacklight Interactive and Team17",
+        "gameGenres": [
+            "Fam\u00edlia e crian\u00e7as",
+            "Esportes"
+        ],
+        "releaseDate": "19/05/2020",
+        "extraGameProperties": {
+            "isInGamePass": true,
+            "controllerSupport": true,
+            "touchControllerSupport": true
+        },
+        "xcloudUrl": "https://www.xbox.com/%s/play/games/golf-with-your-friends/9N14G09PWG74",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.6387.13908316754263937.a2613d65-5012-428e-8936-df4b3295d7bd.7d2ab0ab-de55-4ed7-99d5-6b77de424f11?w=%i&format=jpg",
+        "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.489.13908316754263937.a2613d65-5012-428e-8936-df4b3295d7bd.5fe96ab4-000b-44eb-a706-d506daa5d44b?h=%i&format=jpg",
+        "storeUrl": "https://www.xbox.com/games/store/golf-with-your-friends/9N14G09PWG74"
     },
     {
         "gameTitle": "Gorogoa",
@@ -2442,11 +2405,11 @@
         "releaseDate": "21/05/2018",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/gorogoa/C41M2F4NWB2S",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.11042.66945940929342019.3c8e01a6-6e60-4733-ada9-8cdf420e19fd.10801ac2-a270-44eb-ad4c-6956c2499b23?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.11042.66945940929342019.3c8e01a6-6e60-4733-ada9-8cdf420e19fd.10801ac2-a270-44eb-ad4c-6956c2499b23?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.5340.66945940929342019.3c8e01a6-6e60-4733-ada9-8cdf420e19fd.f5345cf2-78bc-4344-a751-68e3a4359030?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/gorogoa/C41M2F4NWB2S"
     },
@@ -2461,32 +2424,51 @@
         "releaseDate": "27/09/2022",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/grounded/9PJTHRNVH62H",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.36912.14280109286674604.94f3a3e8-211f-41e5-ac9c-d948b5377852.4e9bf257-12e0-4f04-9239-671818df45b0?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.36912.14280109286674604.94f3a3e8-211f-41e5-ac9c-d948b5377852.4e9bf257-12e0-4f04-9239-671818df45b0?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.27514.14280109286674604.1fb359e4-01eb-4818-b992-b225ce4869c9.c9733025-0344-4e66-aff1-ee3bcf9016a7?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/grounded/9PJTHRNVH62H"
     },
     {
-        "gameTitle": "Golf With Your Friends",
-        "gamePublisher": "Team17",
-        "gameDeveloper": "Blacklight Interactive and Team17",
+        "gameTitle": "Gunfire Reborn",
+        "gamePublisher": "505 Games",
+        "gameDeveloper": "Duoyi Games",
         "gameGenres": [
-            "Fam\u00edlia e crian\u00e7as",
-            "Esportes"
+            "A\u00e7\u00e3o e aventura",
+            "Jogos de tiros"
         ],
-        "releaseDate": "19/05/2020",
+        "releaseDate": "27/10/2022",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
-        "xcloudUrl": "https://www.xbox.com/%s/play/games/golf-with-your-friends/9N14G09PWG74",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.6387.13908316754263937.a2613d65-5012-428e-8936-df4b3295d7bd.7d2ab0ab-de55-4ed7-99d5-6b77de424f11?w=%i&h=%i",
-        "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.489.13908316754263937.a2613d65-5012-428e-8936-df4b3295d7bd.5fe96ab4-000b-44eb-a706-d506daa5d44b?h=%i&format=jpg",
-        "storeUrl": "https://www.xbox.com/games/store/golf-with-your-friends/9N14G09PWG74"
+        "xcloudUrl": "https://www.xbox.com/%s/play/games/gunfire-reborn/9P01JWGQGQ9C",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.45820.14465246778810118.73382988-81f5-4c86-83ff-e02b57166b27.f1d0d7fc-3f1f-4cc0-9a71-89d842f64f87?w=%i&format=jpg",
+        "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.10562.14465246778810118.2e560f0f-1dc5-4678-a5a9-479a08e856b0.0b621a0b-9f67-4398-baf9-6760d6e95c1a?h=%i&format=jpg",
+        "storeUrl": "https://www.xbox.com/games/store/gunfire-reborn/9P01JWGQGQ9C"
+    },
+    {
+        "gameTitle": "Gungrave G.O.R.E",
+        "gamePublisher": "Prime Matter",
+        "gameDeveloper": "Iggymob",
+        "gameGenres": [
+            "A\u00e7\u00e3o e aventura",
+            "Luta"
+        ],
+        "releaseDate": "22/11/2022",
+        "extraGameProperties": {
+            "isInGamePass": true,
+            "controllerSupport": true,
+            "touchControllerSupport": false
+        },
+        "xcloudUrl": "https://www.xbox.com/%s/play/games/gungrave-g.o.r.e/9P87CLMPXSN6",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.33649.14093130471487401.df18e01c-f89f-4906-966f-7d30cb5f9f10.ba37ac7d-b4a9-41fc-bc34-55367d2a5348?w=%i&format=jpg",
+        "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.60952.14093130471487401.df18e01c-f89f-4906-966f-7d30cb5f9f10.91c991bd-7e68-4874-a3ed-4c4edb6a0422?h=%i&format=jpg",
+        "storeUrl": "https://www.xbox.com/games/store/gungrave-g.o.r.e/9P87CLMPXSN6"
     },
     {
         "gameTitle": "HITMAN Trilogy",
@@ -2498,11 +2480,11 @@
         "releaseDate": "20/01/2022",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/hitman-trilogy/9NN82NH949D5",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.10042.14144194933273826.3ced5741-3e78-4437-9d89-92e9ac9b74fc.0f724e5e-5cff-424d-9920-a7b0de11eec6?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.10042.14144194933273826.3ced5741-3e78-4437-9d89-92e9ac9b74fc.0f724e5e-5cff-424d-9920-a7b0de11eec6?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.8424.14144194933273826.3ced5741-3e78-4437-9d89-92e9ac9b74fc.731d758a-5b00-4082-887f-693b179a41b2?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/hitman-trilogy/9NN82NH949D5"
     },
@@ -2516,11 +2498,11 @@
         "releaseDate": "26/10/2015",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/halo-5-guardians/BRRC2BP0G9P0",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.64118.69279545232152045.f1a4a87c-fcc9-4b7c-a620-f6c56eb2d5ad.37725d25-3e41-41e7-a2ce-6b0f9994ef5c?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.64118.69279545232152045.f1a4a87c-fcc9-4b7c-a620-f6c56eb2d5ad.37725d25-3e41-41e7-a2ce-6b0f9994ef5c?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.50236.69279545232152045.f1a4a87c-fcc9-4b7c-a620-f6c56eb2d5ad.f0eeb1d4-a30c-4a21-8bcb-46ed84669b5c?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/halo-5-guardians/BRRC2BP0G9P0"
     },
@@ -2534,11 +2516,11 @@
         "releaseDate": "08/12/2021",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/halo-infinite-campaign/9NP1P1WFS0LB",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.56579.13727851868390641.c9cc5f66-aff8-406c-af6b-440838730be0.0dee39b3-efb2-4425-8f1f-087c111ff9b2?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.56579.13727851868390641.c9cc5f66-aff8-406c-af6b-440838730be0.0dee39b3-efb2-4425-8f1f-087c111ff9b2?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.50670.13727851868390641.c9cc5f66-aff8-406c-af6b-440838730be0.d205e025-5444-4eb1-ae46-571ae6895928?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/halo-infinite-campanha/9NP1P1WFS0LB"
     },
@@ -2552,11 +2534,11 @@
         "releaseDate": "20/02/2017",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/halo-wars-2-standard-edition/C42KCJCLX6MX",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.6988.66922732424733865.effc282c-0a95-45c2-8069-86e7e083b3aa.d9a002b9-654e-406f-bce9-4d9de652143a?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.6988.66922732424733865.effc282c-0a95-45c2-8069-86e7e083b3aa.d9a002b9-654e-406f-bce9-4d9de652143a?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.25463.66922732424733865.effc282c-0a95-45c2-8069-86e7e083b3aa.13ca4a16-2390-4552-ac35-49ef77416cb0?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/halo-wars-2-standard-edition/C42KCJCLX6MX"
     },
@@ -2571,11 +2553,11 @@
         "releaseDate": "19/12/2016",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/halo-wars-definitive-edition/BPRPQSKXTD1L",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.58465.68131417927341023.6f4f8f73-402d-42d7-8fff-a37b68438b32.76e8810a-db0d-4b39-9e12-5fd71c6c6ee6?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.58465.68131417927341023.6f4f8f73-402d-42d7-8fff-a37b68438b32.76e8810a-db0d-4b39-9e12-5fd71c6c6ee6?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.41418.68131417927341023.6f4f8f73-402d-42d7-8fff-a37b68438b32.83d52991-7017-4eb8-a444-f551fe8e9be7?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/halo-wars-definitive-edition/BPRPQSKXTD1L"
     },
@@ -2590,11 +2572,11 @@
         "releaseDate": "22/12/2013",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/halo-spartan-assault/BV0K9LMLQ9W5",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.34586.70634858521726340.aed5ca97-d1dc-4d71-ae1f-b3f94bf8b727.2b005ed6-f545-40d3-b5f0-8905ca07b05d?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.34586.70634858521726340.aed5ca97-d1dc-4d71-ae1f-b3f94bf8b727.2b005ed6-f545-40d3-b5f0-8905ca07b05d?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.39086.70634858521726340.aed5ca97-d1dc-4d71-ae1f-b3f94bf8b727.195fa473-3f52-4e68-9ec8-050cc33e4eb4?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/halo-spartan-assault/BV0K9LMLQ9W5"
     },
@@ -2608,11 +2590,11 @@
         "releaseDate": "14/11/2019",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/halo-the-master-chief-collection/9MT8PTGVHX2P",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.16930.13817186670444302.148c432a-9fce-4c7d-bf13-8a2bd3a527b3.99d16324-9915-41d7-a388-fa5dd98940cb?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.16930.13817186670444302.148c432a-9fce-4c7d-bf13-8a2bd3a527b3.99d16324-9915-41d7-a388-fa5dd98940cb?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.36764.13817186670444302.148c432a-9fce-4c7d-bf13-8a2bd3a527b3.2a7b94f3-ed66-45b6-aaf3-337c18d442cd?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/halo-the-master-chief-collection/9MT8PTGVHX2P"
     },
@@ -2627,11 +2609,11 @@
         "releaseDate": "20/09/2022",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/hardspace-shipbreaker/9ND8C4314ZZG",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.11359.13552902647075103.9e24872e-3f43-4078-8279-1ddf37a77ab1.795f17b4-3acd-4226-91d9-5c6031d7899e?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.11359.13552902647075103.9e24872e-3f43-4078-8279-1ddf37a77ab1.795f17b4-3acd-4226-91d9-5c6031d7899e?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.36125.13552902647075103.9e24872e-3f43-4078-8279-1ddf37a77ab1.246fb260-7ac0-4916-867b-dce60a943024?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/hardspace-shipbreaker/9ND8C4314ZZG"
     },
@@ -2645,13 +2627,51 @@
         "releaseDate": "10/04/2018",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/hellblade-senua's-sacrifice/C4Z7QM8FSXM2",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.51441.67453348098260763.a9f96429-c651-425e-97d2-e8861561f15f.73c36cb3-fa0c-4b94-9cdf-abc1f2037096?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.51441.67453348098260763.a9f96429-c651-425e-97d2-e8861561f15f.73c36cb3-fa0c-4b94-9cdf-abc1f2037096?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.41285.67453348098260763.a9f96429-c651-425e-97d2-e8861561f15f.d158352c-5ab5-4cf5-b164-a802f79dcbb4?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/hellblade-senua's-sacrifice/C4Z7QM8FSXM2"
+    },
+    {
+        "gameTitle": "Hello Neighbor 2",
+        "gamePublisher": "tinyBuild",
+        "gameDeveloper": "tinyBuild",
+        "gameGenres": [
+            "A\u00e7\u00e3o e aventura",
+            "Fam\u00edlia e crian\u00e7as"
+        ],
+        "releaseDate": "06/12/2022",
+        "extraGameProperties": {
+            "isInGamePass": true,
+            "controllerSupport": true,
+            "touchControllerSupport": true
+        },
+        "xcloudUrl": "https://www.xbox.com/%s/play/games/hello-neighbor-2/9N961B11FJ4W",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.33283.13538643730533052.28638370-579e-40f3-af52-7a9f26631587.11c36bdc-b917-4415-a3c1-5de382376d4a?w=%i&format=jpg",
+        "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.9994.13538643730533052.28638370-579e-40f3-af52-7a9f26631587.2e51d281-2762-496f-8897-1abdd3ade005?h=%i&format=jpg",
+        "storeUrl": "https://www.xbox.com/games/store/hello-neighbor-2/9N961B11FJ4W"
+    },
+    {
+        "gameTitle": "High On Life",
+        "gamePublisher": "Squanch Games, Inc.",
+        "gameDeveloper": "Squanch Games, Inc.",
+        "gameGenres": [
+            "A\u00e7\u00e3o e aventura",
+            "Outros"
+        ],
+        "releaseDate": "12/12/2022",
+        "extraGameProperties": {
+            "isInGamePass": true,
+            "controllerSupport": true,
+            "touchControllerSupport": false
+        },
+        "xcloudUrl": "https://www.xbox.com/%s/play/games/high-on-life/9NL4714VTLRS",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.45698.13714596773589453.b0e22fc5-f8b4-4b36-b12d-db5d42554c10.bc780adb-55cc-425c-9e65-e86696d7d030?w=%i&format=jpg",
+        "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.37926.13714596773589453.b0e22fc5-f8b4-4b36-b12d-db5d42554c10.3e5bce4c-674d-4a02-82f0-67bec617750d?h=%i&format=jpg",
+        "storeUrl": "https://www.xbox.com/games/store/high-on-life/9NL4714VTLRS"
     },
     {
         "gameTitle": "Hollow Knight: Edi\u00e7\u00e3o Cora\u00e7\u00e3o Vazio",
@@ -2664,11 +2684,11 @@
         "releaseDate": "25/09/2018",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/hollow-knight-voidheart-edition/9MW9469V91LM",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.47695.13847644057609868.a4a91f76-8d1c-4e19-aa78-f4d27d2818fb.090b8af1-1963-48b3-8c6d-1255f335fceb?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.47695.13847644057609868.a4a91f76-8d1c-4e19-aa78-f4d27d2818fb.090b8af1-1963-48b3-8c6d-1255f335fceb?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.24270.13847644057609868.a4a91f76-8d1c-4e19-aa78-f4d27d2818fb.d96146d7-d00a-4db9-ad68-197b2f962a17?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/hollow-knight-edi%C3%A7%C3%A3o-cora%C3%A7%C3%A3o-vazio/9MW9469V91LM"
     },
@@ -2682,11 +2702,11 @@
         "releaseDate": "26/02/2020",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/house-flipper/9NBFGKQLMV33",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.46741.13518543789452586.33e180bb-4f0b-4a39-b1c8-cde6206c1eb3.63c679bb-4c3c-42c4-81bf-e3b3666a61b6?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.46741.13518543789452586.33e180bb-4f0b-4a39-b1c8-cde6206c1eb3.63c679bb-4c3c-42c4-81bf-e3b3666a61b6?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.24765.13518543789452586.d00503fa-1953-4be5-a205-5e65a56ab2f0.794e8686-f38a-4418-9fa5-d9047bf4d77b?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/house-flipper/9NBFGKQLMV33"
     },
@@ -2701,11 +2721,11 @@
         "releaseDate": "11/05/2017",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/human-fall-flat/BSMZH25V6V46",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.36512.69811231537758929.8d40cea0-047e-48e5-89c1-01dd6268bc1f.74d99451-6cd4-48c0-8abf-75d91ab2fad4?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.36512.69811231537758929.8d40cea0-047e-48e5-89c1-01dd6268bc1f.74d99451-6cd4-48c0-8abf-75d91ab2fad4?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.25220.69811231537758929.8d40cea0-047e-48e5-89c1-01dd6268bc1f.11d1a979-c3bd-4094-8358-d4d5a5e74660?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/human-fall-flat/BSMZH25V6V46"
     },
@@ -2720,11 +2740,11 @@
         "releaseDate": "28/06/2016",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/inside/C17GQF31D617",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.26010.65290118777571754.27f1da0f-d581-4307-9bec-41016a2e5567.7b9d8bfe-920c-447d-a3f0-fa336b8d077f?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.26010.65290118777571754.27f1da0f-d581-4307-9bec-41016a2e5567.7b9d8bfe-920c-447d-a3f0-fa336b8d077f?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.20524.65290118777571754.6267d8c2-383e-428a-9ec3-ab8b52cdb946.d9d8d3fc-3054-4fa7-9262-3d2d19c5bad9?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/inside/C17GQF31D617"
     },
@@ -2738,11 +2758,11 @@
         "releaseDate": "27/08/2020",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/immortal-realms-vampire-wars/9P4Q17HQ2WKW",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.32448.14584218626935250.46a9c0b9-f228-4521-a159-9133d5fe93a6.f787427a-eed6-4778-93cd-01e7a182d406?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.32448.14584218626935250.46a9c0b9-f228-4521-a159-9133d5fe93a6.f787427a-eed6-4778-93cd-01e7a182d406?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.49275.14584218626935250.ba95fb18-2711-4235-b9e0-551e8ad946b7.a8b8641c-46cc-4baa-accc-668eb992eff4?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/immortal-realms-vampire-wars/9P4Q17HQ2WKW"
     },
@@ -2756,11 +2776,11 @@
         "releaseDate": "30/08/2022",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/immortality/9PM1905P9LQ6",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.52743.14302926931207469.aafd0cfc-a0f8-4195-84ed-10dd3c27bc62.3d18e51a-7c0f-4500-b194-9772ed4b7305?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.52743.14302926931207469.aafd0cfc-a0f8-4195-84ed-10dd3c27bc62.3d18e51a-7c0f-4500-b194-9772ed4b7305?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.59178.14302926931207469.aafd0cfc-a0f8-4195-84ed-10dd3c27bc62.590efd19-cc96-422c-9b5b-4a6ce60c1b44?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/immortality/9PM1905P9LQ6"
     },
@@ -2774,11 +2794,11 @@
         "releaseDate": "02/12/2020",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/immortals-fenyx-rising/C07KJZRH0L7S",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.55065.64682799204913125.f407971c-f15c-4acc-99e1-682aec54019d.a839231d-b5a5-42ed-8874-ec8165d6f165?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.55065.64682799204913125.f407971c-f15c-4acc-99e1-682aec54019d.a839231d-b5a5-42ed-8874-ec8165d6f165?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.30084.64682799204913125.f407971c-f15c-4acc-99e1-682aec54019d.8b30a1ba-1d1e-4659-8550-022a44a311f3?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/immortals-fenyx-rising/C07KJZRH0L7S"
     },
@@ -2793,11 +2813,11 @@
         "releaseDate": "14/02/2022",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/infernax/9NK7HNCG0R8D",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.3045.13661753595194559.6b97b9b9-2641-4892-950f-db05b0c5fa1c.85ed389e-c6c7-468b-8957-e3ce15d3c8ef?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.3045.13661753595194559.6b97b9b9-2641-4892-950f-db05b0c5fa1c.85ed389e-c6c7-468b-8957-e3ce15d3c8ef?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.38765.13661753595194559.6b97b9b9-2641-4892-950f-db05b0c5fa1c.3d71f16e-50d4-42e2-ad91-23a891a499c0?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/infernax/9NK7HNCG0R8D"
     },
@@ -2811,13 +2831,32 @@
         "releaseDate": "15/05/2017",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/injustice-2/BPKVH4C4XV4N",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.15492.68598211680266771.73ef9826-822a-4a0b-ab4a-4fe8fd87fc3b.fcf3f2a7-591f-4316-a3cc-9a6595d29db9?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.15492.68598211680266771.73ef9826-822a-4a0b-ab4a-4fe8fd87fc3b.fcf3f2a7-591f-4316-a3cc-9a6595d29db9?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.52395.68598211680266771.73ef9826-822a-4a0b-ab4a-4fe8fd87fc3b.81db3eda-d4dd-440a-b266-1973f0472a82?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/injustice-2/BPKVH4C4XV4N"
+    },
+    {
+        "gameTitle": "Insurgency: Sandstorm",
+        "gamePublisher": "Focus Entertainment",
+        "gameDeveloper": "New World Interactive",
+        "gameGenres": [
+            "A\u00e7\u00e3o e aventura",
+            "Jogos de tiros"
+        ],
+        "releaseDate": "29/09/2021",
+        "extraGameProperties": {
+            "isInGamePass": true,
+            "controllerSupport": true,
+            "touchControllerSupport": false
+        },
+        "xcloudUrl": "https://www.xbox.com/%s/play/games/insurgency-sandstorm/C46KTZB9HK8B",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.28821.66496411985646769.c617342d-28e4-4aaf-9b96-89dda9e9d20e.82d12f06-0792-41ee-9436-fa92b1f55f06?w=%i&format=jpg",
+        "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.6975.66496411985646769.c617342d-28e4-4aaf-9b96-89dda9e9d20e.13a82ad7-4c91-4952-aa81-91d965cdabeb?h=%i&format=jpg",
+        "storeUrl": "https://www.xbox.com/games/store/insurgency-sandstorm/C46KTZB9HK8B"
     },
     {
         "gameTitle": "It Takes Two - Vers\u00e3o Digital",
@@ -2829,11 +2868,11 @@
         "releaseDate": "26/03/2021",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/it-takes-two---digital-version/9NXVC0482QS5",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.4452.14488339386131194.84ca8b8a-582e-4d34-904e-8f1e60f71000.1164a903-9308-49c2-a477-3b887cffb341?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.4452.14488339386131194.84ca8b8a-582e-4d34-904e-8f1e60f71000.1164a903-9308-49c2-a477-3b887cffb341?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.40253.14488339386131194.84ca8b8a-582e-4d34-904e-8f1e60f71000.c3aaab37-0ce8-464b-85c1-4f42a74d9972?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/it-takes-two---vers%C3%A3o-digital/9NXVC0482QS5"
     },
@@ -2848,11 +2887,11 @@
         "releaseDate": "22/05/2012",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/joy-ride-turbo/C1ZWH2BZ9TSF",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.55462.65697580773346286.de1a7dea-d35c-459d-a15c-a737811ee00f.6e8da1e2-791b-4bc8-aaf6-a2665f7cdc90?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.55462.65697580773346286.de1a7dea-d35c-459d-a15c-a737811ee00f.6e8da1e2-791b-4bc8-aaf6-a2665f7cdc90?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.59674.65697580773346286.de1a7dea-d35c-459d-a15c-a737811ee00f.39d1596a-d677-44a9-a70a-f9b3d4dae615?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/joy-ride-turbo/C1ZWH2BZ9TSF"
     },
@@ -2867,11 +2906,11 @@
         "releaseDate": "09/11/2021",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/jurassic-world-evolution-2/9MWHMJ0SRBXV",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.57135.13843646153700405.faf0a0ab-da0c-4a73-a182-1b5794b3f805.a540c175-d9d9-48ce-984f-cce5ab49a2d8?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.57135.13843646153700405.faf0a0ab-da0c-4a73-a182-1b5794b3f805.a540c175-d9d9-48ce-984f-cce5ab49a2d8?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.20618.13843646153700405.924d185c-4349-481c-aeb0-1806b6a3fe95.40a43d07-58cb-4315-98f0-946ac06b5ada?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/jurassic-world-evolution-2/9MWHMJ0SRBXV"
     },
@@ -2885,11 +2924,11 @@
         "releaseDate": "06/11/2019",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/just-cause-4-reloaded/9P9MC8B7R5FP",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.65015.14135675770949824.45a1c566-3aee-4e05-b600-cbc49fb16d6d.fb821434-f138-43f5-87d6-22eca4e67fa9?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.65015.14135675770949824.45a1c566-3aee-4e05-b600-cbc49fb16d6d.fb821434-f138-43f5-87d6-22eca4e67fa9?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.767.14135675770949824.45a1c566-3aee-4e05-b600-cbc49fb16d6d.a9fd3630-7e48-41e4-8029-e280aa7a44d4?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/just-cause-4-reloaded/9P9MC8B7R5FP"
     },
@@ -2904,11 +2943,11 @@
         "releaseDate": "10/08/2009",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/kameo/BV83SM3191S5",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.15560.71331020072920166.7e86d9ef-4edb-4eef-a0c8-86f5c9475e2f.aaf8b307-2d84-49cc-af67-613f0a8e8d8e?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.15560.71331020072920166.7e86d9ef-4edb-4eef-a0c8-86f5c9475e2f.aaf8b307-2d84-49cc-af67-613f0a8e8d8e?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.6864.71331020072920166.7e86d9ef-4edb-4eef-a0c8-86f5c9475e2f.53495cd6-6d72-4ef6-8879-874a14ef59d1?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/kameo/BV83SM3191S5"
     },
@@ -2922,11 +2961,11 @@
         "releaseDate": "27/01/2020",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/kentucky-route-zero-tv-edition/9P6FTM76L1S7",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.12186.14620558670939884.b282563f-ef8a-4a4d-8cd6-6780477a8cf6.661c5892-e5d4-40d3-973b-8431fe499724?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.12186.14620558670939884.b282563f-ef8a-4a4d-8cd6-6780477a8cf6.661c5892-e5d4-40d3-973b-8431fe499724?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.46375.14620558670939884.b282563f-ef8a-4a4d-8cd6-6780477a8cf6.b2d48b3e-ee0f-4bb6-8372-aa852f014f97?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/kentucky-route-zero-tv-edition/9P6FTM76L1S7"
     },
@@ -2941,11 +2980,11 @@
         "releaseDate": "04/03/2021",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/kill-it-with-fire/9MZVSHQZ666K",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.12401.13862857064512538.2709e225-b83d-480b-aeaf-58a54a6a45bb.17dd9acd-bdb3-4201-9ec4-a5ff91f3344a?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.12401.13862857064512538.2709e225-b83d-480b-aeaf-58a54a6a45bb.17dd9acd-bdb3-4201-9ec4-a5ff91f3344a?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.16880.13862857064512538.2709e225-b83d-480b-aeaf-58a54a6a45bb.75c585aa-5612-4aa0-98d5-03ff00faf437?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/kill-it-with-fire/9MZVSHQZ666K"
     },
@@ -2959,11 +2998,11 @@
         "releaseDate": "19/09/2016",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/killer-instinct-definitive-edition/BVQ3FL3201P8",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.48860.71051199341094309.0502e995-3a0c-460f-bf9e-3401bb747a61.3decc6eb-56db-4491-8b1b-c9d06d4d5bc6?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.48860.71051199341094309.0502e995-3a0c-460f-bf9e-3401bb747a61.3decc6eb-56db-4491-8b1b-c9d06d4d5bc6?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.38849.71051199341094309.0502e995-3a0c-460f-bf9e-3401bb747a61.e0367efd-a551-4258-9a57-9062964f0b29?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/killer-instinct-definitive-edition/BVQ3FL3201P8"
     },
@@ -2977,32 +3016,50 @@
         "releaseDate": "21/03/2022",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/kraken-academy/9P87CGF1TCCX",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.17451.14093132429705053.80d7d0ce-fb78-4b3f-85e0-84bfb558041a.8594517f-cfdd-4bc2-a491-787adebd921c?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.17451.14093132429705053.80d7d0ce-fb78-4b3f-85e0-84bfb558041a.8594517f-cfdd-4bc2-a491-787adebd921c?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.9836.14093132429705053.80d7d0ce-fb78-4b3f-85e0-84bfb558041a.95449b6c-bc5a-49e5-a4f3-ecaf8ecaad02?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/kraken-academy/9P87CGF1TCCX"
     },
     {
-        "gameTitle": "Lake",
-        "gamePublisher": "Whitethorn Games",
-        "gameDeveloper": "Gamious",
+        "gameTitle": "LAPIN (Game Preview)",
+        "gamePublisher": "Studio Doodal",
+        "gameDeveloper": "Studio Doodal",
         "gameGenres": [
             "A\u00e7\u00e3o e aventura",
-            "Outros"
+            "Plataforma"
         ],
-        "releaseDate": "01/09/2021",
+        "releaseDate": "16/11/2022",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
-        "xcloudUrl": "https://www.xbox.com/%s/play/games/lake/9N5GLFTT40SN",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.60812.14038361809481235.e1ae8557-13ac-43d8-8e4b-bc0fcab05ea7.6b36ea35-f3a1-4d28-bfa0-098b45e73243?w=%i&h=%i",
-        "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.25972.14038361809481235.d87a9a19-dc97-4d6d-96de-9822f1aa65da.3fd66174-aa9a-4c9a-98b5-6b5827742295?h=%i&format=jpg",
-        "storeUrl": "https://www.xbox.com/games/store/lake/9N5GLFTT40SN"
+        "xcloudUrl": "https://www.xbox.com/%s/play/games/lapin-game-preview/9NBQHM0GM30N",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.4556.13578896031022031.669735bf-c2ac-401f-ac66-dd1b562de1d2.d81b23a1-64de-41f4-933a-308cd818b557?w=%i&format=jpg",
+        "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.825.13578896031022031.669735bf-c2ac-401f-ac66-dd1b562de1d2.e8c98327-b7df-4387-8979-749fdbcc2be7?h=%i&format=jpg",
+        "storeUrl": "https://www.xbox.com/games/store/lapin-game-preview/9NBQHM0GM30N"
+    },
+    {
+        "gameTitle": "LEGO\u00ae Star Wars\u2122: A Saga Skywalker",
+        "gamePublisher": "Warner Bros. Games",
+        "gameDeveloper": "TT Games",
+        "gameGenres": [
+            "A\u00e7\u00e3o e aventura"
+        ],
+        "releaseDate": "22/07/2019",
+        "extraGameProperties": {
+            "isInGamePass": true,
+            "controllerSupport": true,
+            "touchControllerSupport": false
+        },
+        "xcloudUrl": "https://www.xbox.com/%s/play/games/lego-star-wars-the-skywalker-saga/BRMKDCZT0C4L",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.7489.69776162813131649.5a0614cf-d90a-4580-90d2-d09e65459d75.24c8420c-5d5f-45f7-b495-59335a7ab2fb?w=%i&format=jpg",
+        "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.58124.69776162813131649.c3b28bba-c81b-49e6-8333-6c1ce8e9222a.8225a765-6b22-437b-bda5-5a65531d716a?h=%i&format=jpg",
+        "storeUrl": "https://www.xbox.com/games/store/lego-star-wars-a-saga-skywalker/BRMKDCZT0C4L"
     },
     {
         "gameTitle": "Lawn Mowing Simulator",
@@ -3014,11 +3071,11 @@
         "releaseDate": "09/08/2021",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/lawn-mowing-simulator/9NPFJTM4HBH9",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.40592.14489216339344377.71f12ec3-85b6-4f74-8483-db150fb3fd51.800c13d5-b95e-454e-81a6-979ed2befbea?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.40592.14489216339344377.71f12ec3-85b6-4f74-8483-db150fb3fd51.800c13d5-b95e-454e-81a6-979ed2befbea?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.17520.14489216339344377.71f12ec3-85b6-4f74-8483-db150fb3fd51.48f85cb5-808d-48c4-ab0a-303d843dac6c?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/lawn-mowing-simulator/9NPFJTM4HBH9"
     },
@@ -3033,11 +3090,11 @@
         "releaseDate": "28/09/2022",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/let's-build-a-zoo/9P8N66DTG10T",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.63900.14084512162357210.0d6eea09-167f-4aad-97d7-d4d17f848799.2a1722e7-328d-4bb3-b556-0d4acae1567b?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.63900.14084512162357210.0d6eea09-167f-4aad-97d7-d4d17f848799.2a1722e7-328d-4bb3-b556-0d4acae1567b?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.15530.14084512162357210.0d6eea09-167f-4aad-97d7-d4d17f848799.9a461717-eb83-4a42-875e-7c96139197b1?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/let's-build-a-zoo/9P8N66DTG10T"
     },
@@ -3051,11 +3108,11 @@
         "releaseDate": "09/09/2021",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/life-is-strange-true-colors/9NFWSNN4JWKB",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.27723.13586428055135571.f12709ac-4fdc-444a-9eb3-a38d712ce6f7.310d4be1-bc01-4faa-98a6-6d4b976eb6dc?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.27723.13586428055135571.f12709ac-4fdc-444a-9eb3-a38d712ce6f7.310d4be1-bc01-4faa-98a6-6d4b976eb6dc?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.45565.13586428055135571.f12709ac-4fdc-444a-9eb3-a38d712ce6f7.5cd24085-d5de-408d-9927-db66e4ecd831?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/life-is-strange-true-colors/9NFWSNN4JWKB"
     },
@@ -3070,11 +3127,11 @@
         "releaseDate": "16/05/2022",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/little-witch-in-the-woods-game-preview/9PM9ZVWT18WR",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.2960.14301619139286382.fe333953-9667-4a52-a6da-789301fea3ca.5aa04ac9-1d35-4f2b-bd14-b536034f06ea?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.2960.14301619139286382.fe333953-9667-4a52-a6da-789301fea3ca.5aa04ac9-1d35-4f2b-bd14-b536034f06ea?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.45320.14301619139286382.fe333953-9667-4a52-a6da-789301fea3ca.cc32a834-82ec-49af-ace2-0a18b633f42c?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/little-witch-in-the-woods-game-preview/9PM9ZVWT18WR"
     },
@@ -3089,11 +3146,11 @@
         "releaseDate": "23/10/2019",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/lonely-mountains-downhill/9MV6MCVLT8GR",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.53295.13794437146560212.1c2132e1-8e75-4ecb-8f54-2474cd20e67a.772f1641-c20b-43ed-8316-94d97f7527a2?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.53295.13794437146560212.1c2132e1-8e75-4ecb-8f54-2474cd20e67a.772f1641-c20b-43ed-8316-94d97f7527a2?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.45145.13794437146560212.1c2132e1-8e75-4ecb-8f54-2474cd20e67a.3b124d2e-22b4-4666-b803-3f467fbfdbc1?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/lonely-mountains-downhill/9MV6MCVLT8GR"
     },
@@ -3108,11 +3165,11 @@
         "releaseDate": "02/05/2022",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/loot-river/9N8C03GW2TRB",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.17035.14047756119637031.8bee70cc-a32a-4d5f-85a7-9d5e7e9b2403.8891593a-1ef2-46ab-aad9-2d4a399625f1?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.17035.14047756119637031.8bee70cc-a32a-4d5f-85a7-9d5e7e9b2403.8891593a-1ef2-46ab-aad9-2d4a399625f1?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.40924.14047756119637031.8bee70cc-a32a-4d5f-85a7-9d5e7e9b2403.29e4c25c-890f-47c6-bc01-8c316225cc12?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/loot-river/9N8C03GW2TRB"
     },
@@ -3127,11 +3184,11 @@
         "releaseDate": "10/09/2021",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/lost-in-random/9NVRJS95FLM9",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.57092.14393276044279732.41dd1f17-b490-46da-821f-ee63792ed90a.860d6901-f703-4d9c-89d7-240528cd607a?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.57092.14393276044279732.41dd1f17-b490-46da-821f-ee63792ed90a.860d6901-f703-4d9c-89d7-240528cd607a?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.44122.14393276044279732.a2dc62ed-f48c-4333-8800-5dd9645ff31a.76e34181-c386-4673-8f9b-15ee3b74f463?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/lost-in-random/9NVRJS95FLM9"
     },
@@ -3145,11 +3202,11 @@
         "releaseDate": "26/01/2022",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/mlb-the-show-22-xbox-series-x-%7C-s/9MXM0G8RP4H4",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.32747.13891780821338361.3fb1a56d-0c2d-43c4-b10e-96729b18d908.5a83ba2e-0e26-417c-9e92-02a5429748d8?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.32747.13891780821338361.3fb1a56d-0c2d-43c4-b10e-96729b18d908.5a83ba2e-0e26-417c-9e92-02a5429748d8?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.34090.13891780821338361.3fb1a56d-0c2d-43c4-b10e-96729b18d908.349a6519-5e19-4415-bee7-799dac45ac47?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/mlb-the-show-22-xbox-series-x-%7C-s/9MXM0G8RP4H4"
     },
@@ -3164,11 +3221,11 @@
         "releaseDate": "21/05/2020",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/maneater/9P5B81KVDGP1",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.16927.14572536018362984.944e7368-3c2f-4b4e-8072-fe5da70a10fa.7c793b5f-5802-41ff-a28a-09de56512b3e?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.16927.14572536018362984.944e7368-3c2f-4b4e-8072-fe5da70a10fa.7c793b5f-5802-41ff-a28a-09de56512b3e?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.53142.14572536018362984.944e7368-3c2f-4b4e-8072-fe5da70a10fa.945db987-dfab-48e8-b6c9-06f3d2db5450?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/maneater/9P5B81KVDGP1"
     },
@@ -3182,11 +3239,11 @@
         "releaseDate": "04/09/2020",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/marvel's-avengers/BRX6HS1G5CDK",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.6955.69399725068812250.e18e30fe-4fd2-40d8-9c22-033732f7b7d3.2747f9ea-dbf7-4274-9066-95e0ae925afc?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.6955.69399725068812250.e18e30fe-4fd2-40d8-9c22-033732f7b7d3.2747f9ea-dbf7-4274-9066-95e0ae925afc?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.24728.69399725068812250.e18e30fe-4fd2-40d8-9c22-033732f7b7d3.4e644a3c-31c2-4c95-a506-798578841474?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/marvel's-avengers/BRX6HS1G5CDK"
     },
@@ -3200,11 +3257,11 @@
         "releaseDate": "26/10/2021",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/marvel's-guardians-of-the-galaxy/9PGLL77C201J",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.25922.14183003051629257.3b865ad2-052d-4fc0-ad6a-2a83af20ce2d.d5f1507b-98e4-44f5-a37c-23cbfd60814f?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.25922.14183003051629257.3b865ad2-052d-4fc0-ad6a-2a83af20ce2d.d5f1507b-98e4-44f5-a37c-23cbfd60814f?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.18029.14183003051629257.3b865ad2-052d-4fc0-ad6a-2a83af20ce2d.6f965e82-c1c8-46bb-affe-f95f37d83625?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/guardi%C3%B5es-da-gal%C3%A1xia-da-marvel/9PGLL77C201J"
     },
@@ -3219,11 +3276,11 @@
         "releaseDate": "14/05/2021",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/mass-effect-legendary-edition/9PKWHT7G60WQ",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.59262.14254372351363255.ac3906d1-13b6-4af0-a00a-e10c8a92007b.dac28bb8-f830-421f-9e92-08a9db8b19f8?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.59262.14254372351363255.ac3906d1-13b6-4af0-a00a-e10c8a92007b.dac28bb8-f830-421f-9e92-08a9db8b19f8?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.32577.14254372351363255.ac3906d1-13b6-4af0-a00a-e10c8a92007b.f74e6e13-69bd-49f0-a873-2f8346a30ead?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/mass-effect-legendary-edition/9PKWHT7G60WQ"
     },
@@ -3237,11 +3294,11 @@
         "releaseDate": "20/03/2017",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/mass-effect-andromeda/BZPR04V49BMH",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.8041.63802047386749134.ad5f99e3-d1a2-49a5-bbb8-b299dc4073ec.526abbab-6137-45f8-a05b-8ace44165345?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.8041.63802047386749134.ad5f99e3-d1a2-49a5-bbb8-b299dc4073ec.526abbab-6137-45f8-a05b-8ace44165345?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.30680.63802047386749134.ad5f99e3-d1a2-49a5-bbb8-b299dc4073ec.54939ac9-4cd6-42f2-97da-9e8136cb7804?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/mass-effect-andromeda/BZPR04V49BMH"
     },
@@ -3255,11 +3312,11 @@
         "releaseDate": "06/07/2022",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/matchpoint---tennis-championships/9P66GGSJR71M",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.54980.14625464772679282.0d11523a-1279-4a53-9b3a-c9af53b152b5.d7c5e229-c9dd-42f9-bc25-73b7a661e445?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.54980.14625464772679282.0d11523a-1279-4a53-9b3a-c9af53b152b5.d7c5e229-c9dd-42f9-bc25-73b7a661e445?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.39673.14625464772679282.0d11523a-1279-4a53-9b3a-c9af53b152b5.8e2f886b-8157-4ad3-9723-2dda8a2aa616?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/matchpoint---tennis-championships/9P66GGSJR71M"
     },
@@ -3274,11 +3331,11 @@
         "releaseDate": "26/05/2021",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/mechwarrior-5-mercenaries/9PB86W3JK8Z5",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.1453.14123304312086404.5dc09435-a0e3-402c-ba22-f58dbbaccd21.e2b9a345-d6e3-4983-ad7d-2d2c5c192d1c?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.1453.14123304312086404.5dc09435-a0e3-402c-ba22-f58dbbaccd21.e2b9a345-d6e3-4983-ad7d-2d2c5c192d1c?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.37063.14123304312086404.5dc09435-a0e3-402c-ba22-f58dbbaccd21.e9d54515-b582-4bc5-8994-795a0037a962?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/mechwarrior-5-mercenaries/9PB86W3JK8Z5"
     },
@@ -3293,11 +3350,11 @@
         "releaseDate": "06/10/2022",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/medieval-dynasty/9PDDP6ML6XHF",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.26306.14156112272410024.03b91df3-d826-4d77-a692-6b75d9b18188.14e344a6-e6f9-43bd-8f8d-f6e965429119?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.26306.14156112272410024.03b91df3-d826-4d77-a692-6b75d9b18188.14e344a6-e6f9-43bd-8f8d-f6e965429119?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.63309.14156112272410024.03b91df3-d826-4d77-a692-6b75d9b18188.85b2f37e-0bd7-4de5-a925-bc86f2c59896?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/medieval-dynasty/9PDDP6ML6XHF"
     },
@@ -3312,31 +3369,31 @@
         "releaseDate": "15/09/2022",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
-        "xcloudUrl": "https://www.xbox.com/%s/play/games/metal-hellsinger/9PDXJP3805DN",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.941.14211614393053975.a4ffed37-2d8b-4964-b012-03eb22bf47cc.6077b8e8-7907-409a-81b2-dd04488234ca?w=%i&h=%i",
+        "xcloudUrl": "https://www.xbox.com/%s/play/games/metal-hellsinger-xbox-series-x%7Cs-pc/9PDXJP3805DN",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.941.14211614393053975.a4ffed37-2d8b-4964-b012-03eb22bf47cc.6077b8e8-7907-409a-81b2-dd04488234ca?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.57354.14211614393053975.a4ffed37-2d8b-4964-b012-03eb22bf47cc.d3b3eebb-84f8-4ed6-9ad4-510a47f020c1?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/metal-hellsinger/9PDXJP3805DN"
     },
     {
-        "gameTitle": "Microsoft Flight Simulator: Standard Game of the Year Edition",
+        "gameTitle": "Microsoft Flight Simulator Standard 40th Anniversary Edition",
         "gamePublisher": "Xbox Game Studios",
         "gameDeveloper": "Asobo Studio",
         "gameGenres": [
             "Simula\u00e7\u00e3o"
         ],
-        "releaseDate": "18/11/2021",
+        "releaseDate": "11/11/2022",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
-        "xcloudUrl": "https://www.xbox.com/%s/play/games/microsoft-flight-simulator-standard-game-of-the-ye/9MTJ74MKQM46",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.52431.13812224868484781.17992d5a-54a4-4eb9-b62c-fbb7cee6d597.67861cc8-eb60-46c2-b21a-034c890d47ae?w=%i&h=%i",
-        "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.45594.13812224868484781.17992d5a-54a4-4eb9-b62c-fbb7cee6d597.0588183a-d39e-442f-b30a-928a8d1a41ce?h=%i&format=jpg",
-        "storeUrl": "https://www.xbox.com/games/store/microsoft-flight-simulator-standard-game-of-the-ye/9MTJ74MKQM46"
+        "xcloudUrl": "https://www.xbox.com/%s/play/games/microsoft-flight-simulator-standard-40th-anniversa/9PMQDM08SNK9",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.37945.14293123921570736.739af26b-0b56-4d3a-8d57-149d26c2cc05.9c568e6b-ca17-4dc8-9c75-efe33e27f910?w=%i&format=jpg",
+        "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.31431.14293123921570736.739af26b-0b56-4d3a-8d57-149d26c2cc05.aea30a4c-375a-4431-ab26-ae7ac415f9ad?h=%i&format=jpg",
+        "storeUrl": "https://www.xbox.com/games/store/microsoft-flight-simulator-standard-40th-anniversa/9PMQDM08SNK9"
     },
     {
         "gameTitle": "Terra-m\u00e9dia\u2122: Sombras da Guerra\u2122",
@@ -3348,11 +3405,11 @@
         "releaseDate": "10/10/2017",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/middle-earth-shadow-of-war/9PDV8FKWP3B4",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.1041.14146895813128195.1152921504736932926.b3b4137c-37ed-4268-8112-002922027d5f?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.1041.14146895813128195.1152921504736932926.b3b4137c-37ed-4268-8112-002922027d5f?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.12292.14146895813128195.1152921504736930957.923ab8a1-bb37-4438-91bf-9e376487014a?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/terra-m%C3%A9dia-sombras-da-guerra/9PDV8FKWP3B4"
     },
@@ -3367,32 +3424,13 @@
         "releaseDate": "23/08/2022",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/midnight-fight-express/9PH1Q5TKPQCQ",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.50615.14244962307093415.153d6882-d2ec-4660-a3c5-c9c093b7ed2d.7664d83e-89b3-44f2-bd2e-f32c3510e006?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.50615.14244962307093415.153d6882-d2ec-4660-a3c5-c9c093b7ed2d.7664d83e-89b3-44f2-bd2e-f32c3510e006?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.59826.14244962307093415.153d6882-d2ec-4660-a3c5-c9c093b7ed2d.4c98d9f0-985b-49c7-8a41-a7a70d178171?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/midnight-fight-express/9PH1Q5TKPQCQ"
-    },
-    {
-        "gameTitle": "Mind Scanners",
-        "gamePublisher": "Brave At Night",
-        "gameDeveloper": "The Outer Zone",
-        "gameGenres": [
-            "RPG",
-            "Simula\u00e7\u00e3o"
-        ],
-        "releaseDate": "29/11/2021",
-        "extraGameProperties": {
-            "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
-        },
-        "xcloudUrl": "https://www.xbox.com/%s/play/games/mind-scanners/9MV8J6MFJNQV",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.64687.13792918252035849.70cae5d6-a601-49fa-aa3f-fe57d9dc8f66.9dad009e-69a8-440f-aba9-c95ff93f087f?w=%i&h=%i",
-        "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.31810.13792918252035849.70cae5d6-a601-49fa-aa3f-fe57d9dc8f66.05f7102e-6f01-4bb2-bacb-7208fd00fbd0?h=%i&format=jpg",
-        "storeUrl": "https://www.xbox.com/games/store/mind-scanners/9MV8J6MFJNQV"
     },
     {
         "gameTitle": "Minecraft Dungeons",
@@ -3405,11 +3443,11 @@
         "releaseDate": "26/05/2020",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/minecraft-dungeons/9N8NJ74FZTG9",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.33021.14045794648370014.2229d39b-90c3-496e-8fac-9987450ca4d8.1d642353-a1d9-490f-882f-e5f16a5b82de?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.33021.14045794648370014.2229d39b-90c3-496e-8fac-9987450ca4d8.1d642353-a1d9-490f-882f-e5f16a5b82de?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.15805.14045794648370014.2229d39b-90c3-496e-8fac-9987450ca4d8.5af45927-45d1-4c93-9d60-26f6ca857701?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/minecraft-dungeons/9N8NJ74FZTG9"
     },
@@ -3423,11 +3461,11 @@
         "releaseDate": "06/06/2016",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/mirror's-edge-catalyst/C48LBRJJCP2L",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.62830.66522486697599341.54595999-7800-48a6-8255-bf581c71e0dd.fdab5a16-85bd-4fa0-9c88-8ec2f16ced89?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.62830.66522486697599341.54595999-7800-48a6-8255-bf581c71e0dd.fdab5a16-85bd-4fa0-9c88-8ec2f16ced89?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.33334.66522486697599341.54595999-7800-48a6-8255-bf581c71e0dd.bec4e523-bef6-4b11-adb9-ae8bedd217fd?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/mirror's-edge-catalyst/C48LBRJJCP2L"
     },
@@ -3442,12 +3480,12 @@
         "releaseDate": "08/12/2020",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/monster-sanctuary/9MZNS9NZ97PF",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.50227.13871023289633408.edeba3ff-23a1-45dd-b6a3-ee86998577d7.6d86b053-b678-4040-8170-875f6344fbc0?w=%i&h=%i",
-        "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.23345.14110383629447010.41bebe3d-b046-4a61-b542-7c01abb0e231.acb13b52-db36-4454-9c83-a01433f36571?h=%i&format=jpg",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.34105.13871023289633408.3b8d784d-b4cc-454a-bad2-973666e4a18a.64278c54-b7db-40e7-a001-db184e048fed?w=%i&format=jpg",
+        "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.43786.13871023289633408.3b8d784d-b4cc-454a-bad2-973666e4a18a.885e7178-5ca4-471f-84dd-ea15a80352f6?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/monster-sanctuary/9MZNS9NZ97PF"
     },
     {
@@ -3461,11 +3499,11 @@
         "releaseDate": "16/12/2020",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/monster-train/9NP4BGBLLLXM",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.48810.13730273714404372.ea561b73-8f7b-40a2-b473-ec2ebf0c6300.88bec4a9-c860-4583-b645-f44bd80755fb?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.48810.13730273714404372.ea561b73-8f7b-40a2-b473-ec2ebf0c6300.88bec4a9-c860-4583-b645-f44bd80755fb?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.3476.13730273714404372.ea561b73-8f7b-40a2-b473-ec2ebf0c6300.a0456ffb-9f54-4851-9a96-db7ea3d8f23b?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/monster-train/9NP4BGBLLLXM"
     },
@@ -3480,11 +3518,11 @@
         "releaseDate": "25/10/2021",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/moonglow-bay/9P7VCSGBP9KL",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.7691.14100376622407307.eeb47dd8-8d38-411a-9501-284e813ed3bb.fdc1735e-8942-4170-8ed8-653bd1ec8caf?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.7691.14100376622407307.eeb47dd8-8d38-411a-9501-284e813ed3bb.fdc1735e-8942-4170-8ed8-653bd1ec8caf?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.19597.14100376622407307.eeb47dd8-8d38-411a-9501-284e813ed3bb.23af0646-38ca-4310-8074-2928bdabc37c?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/moonglow-bay/9P7VCSGBP9KL"
     },
@@ -3498,11 +3536,11 @@
         "releaseDate": "29/05/2018",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/moonlighter/9P8XJRLCLH2P",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.23038.14078999020725962.ddb83977-3b2d-4498-aa21-0a1bdeb1cddc.b1c79423-8a23-4943-804b-c5333d258492?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.23038.14078999020725962.ddb83977-3b2d-4498-aa21-0a1bdeb1cddc.b1c79423-8a23-4943-804b-c5333d258492?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.24606.14078999020725962.ddb83977-3b2d-4498-aa21-0a1bdeb1cddc.a7338ebd-e2fa-4523-a136-b3789f1f6fb6?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/moonlighter/9P8XJRLCLH2P"
     },
@@ -3517,11 +3555,11 @@
         "releaseDate": "27/09/2022",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/moonscars/9P77VD8MGJX8",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.48607.14609228948314679.57b5d232-e029-48c3-a08c-a51885c8f604.a75be4f6-a08c-465f-8452-bf3c2ee5da75?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.48607.14609228948314679.57b5d232-e029-48c3-a08c-a51885c8f604.a75be4f6-a08c-465f-8452-bf3c2ee5da75?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.16286.14609228948314679.57b5d232-e029-48c3-a08c-a51885c8f604.af5bedd3-16ab-4c9d-a23d-deda8b3b585f?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/moonscars/9P77VD8MGJX8"
     },
@@ -3535,32 +3573,13 @@
         "releaseDate": "22/04/2019",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/mortal-kombat-11/BTC0L0BW6LWC",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.63277.70804610839547354.8da93c46-fd13-4b16-8ebe-e8e02c53d93e.9d395244-d5c3-4d17-a83d-2ff95537c0f6?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.63277.70804610839547354.8da93c46-fd13-4b16-8ebe-e8e02c53d93e.9d395244-d5c3-4d17-a83d-2ff95537c0f6?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.31077.70804610839547354.8da93c46-fd13-4b16-8ebe-e8e02c53d93e.032a1c73-7961-4acf-a82a-89d2f3ccdd1f?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/mortal-kombat-11/BTC0L0BW6LWC"
-    },
-    {
-        "gameTitle": "Mortal Shell: Enhanced Edition",
-        "gamePublisher": "Playstack",
-        "gameDeveloper": "Cold Symmetry",
-        "gameGenres": [
-            "A\u00e7\u00e3o e aventura",
-            "Outros"
-        ],
-        "releaseDate": "18/08/2020",
-        "extraGameProperties": {
-            "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
-        },
-        "xcloudUrl": "https://www.xbox.com/%s/play/games/mortal-shell-enhanced-edition/9PC2BJDXR2LK",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.60033.14112185653659482.b5e15e3a-13c2-47bd-9e60-7709b165611f.727ea54e-9116-49fb-9def-e303eda19df8?w=%i&h=%i",
-        "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.48998.14112185653659482.b5e15e3a-13c2-47bd-9e60-7709b165611f.1a8e8ab6-788c-41d0-8d25-cedfa921075d?h=%i&format=jpg",
-        "storeUrl": "https://www.xbox.com/games/store/mortal-shell-enhanced-edition/9PC2BJDXR2LK"
     },
     {
         "gameTitle": "MotoGP\u212222",
@@ -3573,11 +3592,11 @@
         "releaseDate": "21/04/2022",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/motogp22/9P6N58X27150",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.38272.14616445086878693.b5e88527-6d84-46b3-aedb-b4ca1a01a63e.303843a3-9ef9-4014-8dbb-c89f6584b086?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.38272.14616445086878693.b5e88527-6d84-46b3-aedb-b4ca1a01a63e.303843a3-9ef9-4014-8dbb-c89f6584b086?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.15559.14616445086878693.b5e88527-6d84-46b3-aedb-b4ca1a01a63e.b31f234a-d4e9-4e75-9c39-592ef3632d31?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/motogp22/9P6N58X27150"
     },
@@ -3592,11 +3611,11 @@
         "releaseDate": "04/12/2019",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/my-friend-pedro/9P16M6LF0QFH",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.40064.14517273440942106.95022d0f-01e8-4fa1-a16a-b7fa27a20afd.64ddf521-d35e-4239-a6ad-fbec57d06bde?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.40064.14517273440942106.95022d0f-01e8-4fa1-a16a-b7fa27a20afd.64ddf521-d35e-4239-a6ad-fbec57d06bde?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.21399.14517273440942106.95022d0f-01e8-4fa1-a16a-b7fa27a20afd.fe2afe97-b88e-417e-afdf-1e2b9968eda3?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/my-friend-pedro/9P16M6LF0QFH"
     },
@@ -3610,11 +3629,11 @@
         "releaseDate": "22/10/2021",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/my-friend-peppa-pig/9NDJLXD2X2DM",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.41714.13613420443671332.a6ea2e8e-4acd-4934-b589-2d8cfaba7189.2f819a75-49ec-4ddd-858c-0752a4ae517a?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.41714.13613420443671332.a6ea2e8e-4acd-4934-b589-2d8cfaba7189.2f819a75-49ec-4ddd-858c-0752a4ae517a?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.16203.13613420443671332.a6ea2e8e-4acd-4934-b589-2d8cfaba7189.787c1e94-55bb-4581-806d-fc1d213da277?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/minha-amiga-peppa-pig/9NDJLXD2X2DM"
     },
@@ -3628,11 +3647,11 @@
         "releaseDate": "15/04/2019",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/my-time-at-portia/BX1FZX1X4132",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.8924.63380265586365831.1555bbb7-7743-4e40-af30-9522b68b2b3c.9ec78f2b-f34d-413c-b72f-31d62eb51f09?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.8924.63380265586365831.1555bbb7-7743-4e40-af30-9522b68b2b3c.9ec78f2b-f34d-413c-b72f-31d62eb51f09?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.27124.63380265586365831.1555bbb7-7743-4e40-af30-9522b68b2b3c.4000aac7-cfe0-4fcb-b9c2-a91cba69048e?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/my-time-at-portia/BX1FZX1X4132"
     },
@@ -3646,11 +3665,11 @@
         "releaseDate": "23/06/2022",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/naraka-bladepoint---standard-edition/9MVVDHS95RCL",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.63321.13856197661114247.d18d95b4-04ab-4306-83a8-f6f7868b9215.8d21aeec-01d7-4eb0-873f-50adc19d0699?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.63321.13856197661114247.d18d95b4-04ab-4306-83a8-f6f7868b9215.8d21aeec-01d7-4eb0-873f-50adc19d0699?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.13827.13856197661114247.d18d95b4-04ab-4306-83a8-f6f7868b9215.1c38d90a-faa5-422f-98a4-e916379caea7?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/naraka-bladepoint---edi%C3%A7%C3%A3o-standard/9MVVDHS95RCL"
     },
@@ -3664,11 +3683,11 @@
         "releaseDate": "09/06/2021",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/ninja-gaiden-3-razor's-edge/9N27DBP8GNNB",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.34045.13957002730398149.0cea4e4d-b211-438d-b3fc-78fd52485184.fc4f1171-49f7-4812-b943-3ed19812f720?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.34045.13957002730398149.0cea4e4d-b211-438d-b3fc-78fd52485184.fc4f1171-49f7-4812-b943-3ed19812f720?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.57988.13957002730398149.0cea4e4d-b211-438d-b3fc-78fd52485184.fc986eb9-ad62-426f-ad0b-81b66ca9bf53?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/ninja-gaiden-3-razor's-edge/9N27DBP8GNNB"
     },
@@ -3682,11 +3701,11 @@
         "releaseDate": "09/06/2021",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/ninja-gaiden-%CF%83/9NZ5QW71X49G",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.19050.14486675416442203.186df2ad-99aa-4e4f-bcb4-cb37ca999946.df485081-ec17-460b-9e62-e385c1297574?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.19050.14486675416442203.186df2ad-99aa-4e4f-bcb4-cb37ca999946.df485081-ec17-460b-9e62-e385c1297574?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.3733.14486675416442203.186df2ad-99aa-4e4f-bcb4-cb37ca999946.9fecacb7-4e26-423b-a102-806174d893fa?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/ninja-gaiden-%CF%83/9NZ5QW71X49G"
     },
@@ -3700,13 +3719,31 @@
         "releaseDate": "09/06/2021",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/ninja-gaiden-%CF%832/9PGSC3PW4N8Z",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.62138.14245467679473898.001107c4-7d89-4b24-ae55-6960d7565280.fde9e16e-7907-4d7f-802e-22f2da8e8667?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.62138.14245467679473898.001107c4-7d89-4b24-ae55-6960d7565280.fde9e16e-7907-4d7f-802e-22f2da8e8667?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.51238.14245467679473898.001107c4-7d89-4b24-ae55-6960d7565280.ce96479e-ba13-4c86-b16c-6dc1855dfde5?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/ninja-gaiden-%CF%832/9PGSC3PW4N8Z"
+    },
+    {
+        "gameTitle": "NORCO",
+        "gamePublisher": "Raw Fury",
+        "gameDeveloper": "Geography of Robots",
+        "gameGenres": [
+            "A\u00e7\u00e3o e aventura"
+        ],
+        "releaseDate": "23/03/2022",
+        "extraGameProperties": {
+            "isInGamePass": true,
+            "controllerSupport": true,
+            "touchControllerSupport": false
+        },
+        "xcloudUrl": "https://www.xbox.com/%s/play/games/norco/9NZFZXDRZQLR",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.25342.14481237140487412.88b201c5-42cf-43cc-af65-86f48324703c.ffed0473-d7e2-4f24-9dc3-b665a6eae08a?w=%i&format=jpg",
+        "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.28816.14481237140487412.88b201c5-42cf-43cc-af65-86f48324703c.af71efde-62f6-4a00-8353-872b67548d33?h=%i&format=jpg",
+        "storeUrl": "https://www.xbox.com/games/store/norco/9NZFZXDRZQLR"
     },
     {
         "gameTitle": "Need for Speed\u2122 Heat",
@@ -3718,12 +3755,12 @@
         "releaseDate": "07/11/2019",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/need-for-speed-heat/BRZZLBF5T245",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.64382.69435230515002378.b30b404a-238a-48e8-8b5e-96664f17ed38.a02f1bcb-53dc-4074-adae-9bff70c7e646?w=%i&h=%i",
-        "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.54237.69435230515002378.b30b404a-238a-48e8-8b5e-96664f17ed38.02fe8a52-9076-42cd-abc5-521975a572b0?h=%i&format=jpg",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.46671.69435230515002378.477c7a96-5d17-45ec-95c2-a2739146b68d.f84cd83e-a0cc-42f8-87cb-4c8b0d664eb5?w=%i&format=jpg",
+        "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.8294.69435230515002378.477c7a96-5d17-45ec-95c2-a2739146b68d.fd377b26-2212-4834-b9f4-b14e17f411ec?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/need-for-speed-heat/BRZZLBF5T245"
     },
     {
@@ -3737,32 +3774,13 @@
         "releaseDate": "06/11/2020",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/need-for-speed-hot-pursuit-remastered/9NMBJQ0265ZK",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.50193.13695403561576988.5461aeea-bae0-45c6-b5d4-5d6c85d1216c.9a0f44da-d2ef-442a-a767-3ef1ff4650a6?w=%i&h=%i",
-        "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.47104.13695403561576988.5461aeea-bae0-45c6-b5d4-5d6c85d1216c.25dcbbc6-1380-4850-8611-16c0d37f7168?h=%i&format=jpg",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.54645.13695403561576988.ee93f06a-1e4b-49d1-aa54-9b9583915442.1a1438a8-4154-40ee-94bd-51deda46184d?w=%i&format=jpg",
+        "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.5450.13695403561576988.ee93f06a-1e4b-49d1-aa54-9b9583915442.cef738f8-7a52-40cb-b8c1-65d9e60e8007?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/need-for-speed-hot-pursuit-remastered/9NMBJQ0265ZK"
-    },
-    {
-        "gameTitle": "Neoverse",
-        "gamePublisher": "SK Telecom.co, Ltd.",
-        "gameDeveloper": "TINO GAMES Inc.",
-        "gameGenres": [
-            "Cartas e tabuleiro",
-            "Estrat\u00e9gia"
-        ],
-        "releaseDate": "16/12/2020",
-        "extraGameProperties": {
-            "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
-        },
-        "xcloudUrl": "https://www.xbox.com/%s/play/games/neoverse/9NNSTP6KJTZ9",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.15039.13732308681387652.912ddfff-827b-4ec6-879c-11fe5776733d.4e326538-4399-4261-915b-16889e375da8?w=%i&h=%i",
-        "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.65226.13732308681387652.912ddfff-827b-4ec6-879c-11fe5776733d.16e951e2-5ad9-400d-8501-88cc84ac6b9f?h=%i&format=jpg",
-        "storeUrl": "https://www.xbox.com/games/store/neoverse/9NNSTP6KJTZ9"
     },
     {
         "gameTitle": "New Super Lucky's Tale",
@@ -3775,32 +3793,13 @@
         "releaseDate": "21/08/2020",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/new-super-lucky's-tale/9MZN3SMXN824",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.42417.13867280688858311.8624d86c-7857-440e-9303-9897a29ba67e.42b5def2-8e7f-4ff7-a75b-72354e44d97e?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.42417.13867280688858311.8624d86c-7857-440e-9303-9897a29ba67e.42b5def2-8e7f-4ff7-a75b-72354e44d97e?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.3998.13867280688858311.8624d86c-7857-440e-9303-9897a29ba67e.85558656-0ed2-4a79-9abb-424d9edcda0a?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/new-super-lucky's-tale/9MZN3SMXN824"
-    },
-    {
-        "gameTitle": "Next Space Rebels",
-        "gamePublisher": "Humble Games",
-        "gameDeveloper": "Studio Floris Kaayk",
-        "gameGenres": [
-            "Outros",
-            "Desafios"
-        ],
-        "releaseDate": "17/11/2021",
-        "extraGameProperties": {
-            "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
-        },
-        "xcloudUrl": "https://www.xbox.com/%s/play/games/next-space-rebels/9PBGCRBQKXTP",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.64109.14119640268172716.d5337920-4722-41a0-b754-c6d32e905713.e82cc454-38a7-4868-8490-f79b73c8312f?w=%i&h=%i",
-        "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.59031.14119640268172716.d5337920-4722-41a0-b754-c6d32e905713.5f306222-ac0a-43c5-adff-2debc38b87a3?h=%i&format=jpg",
-        "storeUrl": "https://www.xbox.com/games/store/next-space-rebels/9PBGCRBQKXTP"
     },
     {
         "gameTitle": "Ni no Kuni Wrath of the White Witch\u2122 Remastered",
@@ -3812,11 +3811,11 @@
         "releaseDate": "15/09/2022",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/ni-no-kuni-wrath-of-the-white-witch-remastered/9P7SL78VHVMF",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.57893.14101239125163632.01de9600-be68-4ca2-ad44-3bd38be94a52.4b2ed267-ccba-45eb-b8bd-97484e350d07?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.57893.14101239125163632.01de9600-be68-4ca2-ad44-3bd38be94a52.4b2ed267-ccba-45eb-b8bd-97484e350d07?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.11224.14101239125163632.01de9600-be68-4ca2-ad44-3bd38be94a52.115cbde1-1f23-46f0-8ab3-13e6fbcd5ea1?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/ni-no-kuni-wrath-of-the-white-witch-remastered/9P7SL78VHVMF"
     },
@@ -3831,11 +3830,11 @@
         "releaseDate": "23/07/2018",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/no-man's-sky/BQVQTL3PCH05",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.59103.68818099466568894.5fae376b-4fd4-4e61-a81c-a5575757b3b1.f5794177-89b9-4d01-b006-1402f1aae16c?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.59103.68818099466568894.5fae376b-4fd4-4e61-a81c-a5575757b3b1.f5794177-89b9-4d01-b006-1402f1aae16c?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.15580.68818099466568894.5fae376b-4fd4-4e61-a81c-a5575757b3b1.9532faae-3b75-43f9-ac89-228908154773?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/no-man's-sky/BQVQTL3PCH05"
     },
@@ -3850,32 +3849,13 @@
         "releaseDate": "18/01/2022",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/nobody-saves-the-world/9NFZ65KKJ10X",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.53413.13585830814774327.d6e142bb-27e2-4109-8139-edac768eca10.bd597240-e065-42b4-a809-b42e4a7a9815?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.53413.13585830814774327.d6e142bb-27e2-4109-8139-edac768eca10.bd597240-e065-42b4-a809-b42e4a7a9815?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.10184.13585830814774327.d6e142bb-27e2-4109-8139-edac768eca10.4233d247-29c3-40cb-8464-f762cb01cbef?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/nobody-saves-the-world/9NFZ65KKJ10X"
-    },
-    {
-        "gameTitle": "Nongunz: Doppelganger Edition",
-        "gamePublisher": "Digerati",
-        "gameDeveloper": "Brainwash Gang / Kittehface",
-        "gameGenres": [
-            "A\u00e7\u00e3o e aventura",
-            "Plataforma"
-        ],
-        "releaseDate": "06/05/2021",
-        "extraGameProperties": {
-            "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
-        },
-        "xcloudUrl": "https://www.xbox.com/%s/play/games/nongunz-doppelganger-edition/9NRDVCW02JD7",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.13510.14389204367011736.3e1e89b1-9b12-46d7-a373-9348f56d1999.2374e012-8afd-4e41-acc1-2d15f23b0f81?w=%i&h=%i",
-        "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.39117.14389204367011736.3e1e89b1-9b12-46d7-a373-9348f56d1999.3bbc5593-9036-49ce-bdbe-66f4731f65c0?h=%i&format=jpg",
-        "storeUrl": "https://www.xbox.com/games/store/nongunz-doppelganger-edition/9NRDVCW02JD7"
     },
     {
         "gameTitle": "Nuclear Throne",
@@ -3887,11 +3867,11 @@
         "releaseDate": "08/09/2021",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/nuclear-throne/9PCCFDH6LMQJ",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.45919.14171913677755527.7e192ea5-4d8a-4cd4-8882-2ee02006dca6.ec5431c5-cd06-42a4-8e49-d3d44661887f?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.45919.14171913677755527.7e192ea5-4d8a-4cd4-8882-2ee02006dca6.ec5431c5-cd06-42a4-8e49-d3d44661887f?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.64049.14171913677755527.67ba416c-4030-4b8b-9fbf-42a68fbf3665.370f6d61-4597-4d1c-9619-218684dc419c?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/nuclear-throne/9PCCFDH6LMQJ"
     },
@@ -3905,11 +3885,11 @@
         "releaseDate": "24/03/2021",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/octopath-traveler/9N9606CC950J",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.18141.13539010844025035.cd25451c-c47c-45c8-b378-724488a9e769.8071ec1d-5580-4953-94a4-08c603c7e808?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.18141.13539010844025035.cd25451c-c47c-45c8-b378-724488a9e769.8071ec1d-5580-4953-94a4-08c603c7e808?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.53807.13539010844025035.cd25451c-c47c-45c8-b378-724488a9e769.8364beae-f919-4489-bd3c-6d533470324a?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/octopath-traveler/9N9606CC950J"
     },
@@ -3923,31 +3903,13 @@
         "releaseDate": "16/06/2022",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/omori/9P8WMQ1S4TF9",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.63765.14079624955953364.e347e65c-a873-4507-900a-8f8da39e1b5e.43fca221-a279-4413-b1f5-0cebd4e6c80d?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.63765.14079624955953364.e347e65c-a873-4507-900a-8f8da39e1b5e.43fca221-a279-4413-b1f5-0cebd4e6c80d?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.29601.14079624955953364.e347e65c-a873-4507-900a-8f8da39e1b5e.065ccec7-e1fd-4dbf-8ef6-37f6f6d72b69?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/omori/9P8WMQ1S4TF9"
-    },
-    {
-        "gameTitle": "ONE PIECE PIRATE WARRIORS 4",
-        "gamePublisher": "BANDAI NAMCO Entertainment",
-        "gameDeveloper": "--",
-        "gameGenres": [
-            "A\u00e7\u00e3o e aventura"
-        ],
-        "releaseDate": "27/03/2020",
-        "extraGameProperties": {
-            "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
-        },
-        "xcloudUrl": "https://www.xbox.com/%s/play/games/one-piece-pirate-warriors-4/9N6HB778ZWP2",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.29551.14013874404154427.01749ccd-5277-41b8-9db6-ca15905ced80.a8c1d3c0-4e29-4d7c-98de-5c32552fec0a?w=%i&h=%i",
-        "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.3120.14013874404154427.01749ccd-5277-41b8-9db6-ca15905ced80.9761c64f-4d3e-4131-9148-c75c7f7bf7de?h=%i&format=jpg",
-        "storeUrl": "https://www.xbox.com/games/store/one-piece-pirate-warriors-4/9N6HB778ZWP2"
     },
     {
         "gameTitle": "OPUS: Echo of Starsong - Full Bloom Edition",
@@ -3960,11 +3922,11 @@
         "releaseDate": "24/08/2022",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/opus-echo-of-starsong---full-bloom-edition/9NKKDCVR3VW9",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.10319.13659592663783828.c218620d-b41e-4037-9cc0-e5ec840c80aa.632cb077-44e2-4f26-a70f-d2d9319885bf?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.10319.13659592663783828.c218620d-b41e-4037-9cc0-e5ec840c80aa.632cb077-44e2-4f26-a70f-d2d9319885bf?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.34255.13659592663783828.c218620d-b41e-4037-9cc0-e5ec840c80aa.1aeabba3-0a7e-404c-9598-4f268268e30e?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/opus-echo-of-starsong---full-bloom-edition/9NKKDCVR3VW9"
     },
@@ -3979,11 +3941,11 @@
         "releaseDate": "31/03/2021",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/outriders/C083G6BGJ334",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.46955.64676761359365869.c6056fd3-1a88-4909-9197-e47917a0daf9.ab2ec758-0b35-43db-83ca-596f30f3ee25?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.46955.64676761359365869.c6056fd3-1a88-4909-9197-e47917a0daf9.ab2ec758-0b35-43db-83ca-596f30f3ee25?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.56574.64676761359365869.4c4dfa98-d983-48f6-8be8-947cb40983a7.b459f4f1-1077-458a-ac01-ef6b27d70259?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/outriders/C083G6BGJ334"
     },
@@ -3998,32 +3960,13 @@
         "releaseDate": "28/01/2021",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/olija/9N6PB00DXQ7H",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.1798.14014649267663230.52cdcd0a-d270-4877-9bec-d99419176577.babaad03-70b2-4054-99a2-78cda280cc86?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.1798.14014649267663230.52cdcd0a-d270-4877-9bec-d99419176577.babaad03-70b2-4054-99a2-78cda280cc86?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.62077.14014649267663230.52cdcd0a-d270-4877-9bec-d99419176577.6d22e768-29fc-458a-b5c8-fec8db421247?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/olija/9N6PB00DXQ7H"
-    },
-    {
-        "gameTitle": "One Step From Eden",
-        "gamePublisher": "Humble Games",
-        "gameDeveloper": "Thomas Moon Kang",
-        "gameGenres": [
-            "A\u00e7\u00e3o e aventura",
-            "Jogos de tiros"
-        ],
-        "releaseDate": "10/11/2021",
-        "extraGameProperties": {
-            "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
-        },
-        "xcloudUrl": "https://www.xbox.com/%s/play/games/one-step-from-eden/9N4K8K2ZGF1L",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.55511.13981836529399843.3570f80e-7819-4f87-b589-3809aeb668e9.ddcae108-9ddc-424e-9d20-08456c042346?w=%i&h=%i",
-        "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.33011.13981836529399843.3570f80e-7819-4f87-b589-3809aeb668e9.2f8a517b-8c9a-4ac3-9b87-28ae4a05f0c8?h=%i&format=jpg",
-        "storeUrl": "https://www.xbox.com/games/store/one-step-from-eden/9N4K8K2ZGF1L"
     },
     {
         "gameTitle": "Ori and the Blind Forest: Definitive Edition",
@@ -4036,11 +3979,11 @@
         "releaseDate": "10/03/2016",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/ori-and-the-blind-forest-definitive-edition/BW85KQB8Q31M",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.33006.71930896676716842.b6740fa4-0359-4ca8-9e17-5d4e45c2d497.106c936e-9312-4ea3-b2c1-d6ea54a4377d?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.33006.71930896676716842.b6740fa4-0359-4ca8-9e17-5d4e45c2d497.106c936e-9312-4ea3-b2c1-d6ea54a4377d?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.3754.71930896676716842.b6740fa4-0359-4ca8-9e17-5d4e45c2d497.9c175dbd-1b8c-47b2-bb1c-d23a73dba0b2?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/ori-and-the-blind-forest-definitive-edition/BW85KQB8Q31M"
     },
@@ -4055,11 +3998,11 @@
         "releaseDate": "11/03/2020",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/ori-and-the-will-of-the-wisps/9N8CD0XZKLP4",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.37519.14047496556148589.9fda5cef-7995-4dbb-a626-66d2ab3feb4f.c81b9aaa-f139-44ac-b9ca-0aa0dd0cbffb?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.37519.14047496556148589.9fda5cef-7995-4dbb-a626-66d2ab3feb4f.c81b9aaa-f139-44ac-b9ca-0aa0dd0cbffb?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.40411.14047496556148589.9fda5cef-7995-4dbb-a626-66d2ab3feb4f.d87f046c-667d-4ce7-98bc-eba2b535dc94?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/ori-and-the-will-of-the-wisps/9N8CD0XZKLP4"
     },
@@ -4074,11 +4017,11 @@
         "releaseDate": "29/05/2019",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/outer-wilds/C596FKDKMQN7",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.38686.67120997535715720.38c3e502-0019-4560-826e-634bbaf5cb4b.26a27298-66b5-489a-83dc-b1741a12905f?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.38686.67120997535715720.38c3e502-0019-4560-826e-634bbaf5cb4b.26a27298-66b5-489a-83dc-b1741a12905f?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.22579.67120997535715720.38c3e502-0019-4560-826e-634bbaf5cb4b.d08b8fa2-f53a-46ef-a7b9-486040abe414?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/outer-wilds/C596FKDKMQN7"
     },
@@ -4092,11 +4035,11 @@
         "releaseDate": "06/08/2018",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/overcooked-2/BVJLKDG2TX8H",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.60458.70952388438497888.9a8a7127-1933-427d-b864-f4857d4c02fd.734afa54-8396-4590-8a61-9565e4eeca71?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.60458.70952388438497888.9a8a7127-1933-427d-b864-f4857d4c02fd.734afa54-8396-4590-8a61-9565e4eeca71?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.22394.70952388438497888.9a8a7127-1933-427d-b864-f4857d4c02fd.5e9c5e67-db11-4c9e-a360-9ab9317594c5?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/overcooked-2/BVJLKDG2TX8H"
     },
@@ -4111,11 +4054,11 @@
         "releaseDate": "26/05/2022",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/pac-man-museum/9P6W2Q41BB8V",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.41708.14612183358312597.ac18d1d8-4c6f-4fc0-aa76-31549ff4c4cc.27daf2c6-bb6f-45f5-95e6-81f19c23b533?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.41708.14612183358312597.ac18d1d8-4c6f-4fc0-aa76-31549ff4c4cc.27daf2c6-bb6f-45f5-95e6-81f19c23b533?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.7949.14612183358312597.ac18d1d8-4c6f-4fc0-aa76-31549ff4c4cc.4468f88e-e375-427b-bcdb-9b4f17dd774d?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/pac-man-museum/9P6W2Q41BB8V"
     },
@@ -4130,11 +4073,11 @@
         "releaseDate": "05/11/2020",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/paw-patrol-mighty-pups-save-adventure-bay/9N3TF03KNTBD",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.3013.13996206863599819.e2c5aea7-cee9-4965-bcf2-983a449c260d.3492e484-91a4-4558-b189-66444c715f51?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.3013.13996206863599819.e2c5aea7-cee9-4965-bcf2-983a449c260d.3492e484-91a4-4558-b189-66444c715f51?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.21390.13996206863599819.e2c5aea7-cee9-4965-bcf2-983a449c260d.a0878837-f0e2-4ccd-83cf-707c7f9b44bd?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/patrulha-canina-super-filhotes-salvam-a-ba%C3%ADa-da-av/9N3TF03KNTBD"
     },
@@ -4149,11 +4092,11 @@
         "releaseDate": "13/08/2021",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/paw-patrol-the-movie-adventure-city-calls/9NVN8NSXDK41",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.52763.14390988319138042.36b13a64-9b0f-4a63-975d-6accaeba2284.1e37bfc8-9556-4feb-8d93-f976b08ef10c?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.52763.14390988319138042.36b13a64-9b0f-4a63-975d-6accaeba2284.1e37bfc8-9556-4feb-8d93-f976b08ef10c?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.42826.14390988319138042.36b13a64-9b0f-4a63-975d-6accaeba2284.2f1fc250-8ed1-42e1-bf2f-bef318166a0c?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/patrulha-canina-o-filme-a-cidade-da-aventura-est%C3%A1-/9NVN8NSXDK41"
     },
@@ -4168,11 +4111,11 @@
         "releaseDate": "29/09/2022",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/paw-patrol-grand-prix/9MWBT3HFCZ3Z",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.30417.13842132658396836.fba80705-9bc9-45ad-84f9-621f75fe99ec.63412d4a-24e5-449a-9622-75435adb7a73?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.30417.13842132658396836.fba80705-9bc9-45ad-84f9-621f75fe99ec.63412d4a-24e5-449a-9622-75435adb7a73?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.53527.13842132658396836.fba80705-9bc9-45ad-84f9-621f75fe99ec.a7d39a33-f2c3-408b-a88d-4ef40eb5c446?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/patrulha-canina-grand-prix/9MWBT3HFCZ3Z"
     },
@@ -4187,11 +4130,11 @@
         "releaseDate": "16/03/2022",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/paradise-killer/9N673ZL1TCS7",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.55008.14023862983584172.71823e2e-c6b2-4372-a1b9-ec0708e514ce.1e206981-3371-4322-90e7-9da6f6a051dc?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.55008.14023862983584172.71823e2e-c6b2-4372-a1b9-ec0708e514ce.1e206981-3371-4322-90e7-9da6f6a051dc?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.29823.14023862983584172.71823e2e-c6b2-4372-a1b9-ec0708e514ce.16cb92c1-927e-4e06-bcbc-c7dbc1794014?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/paradise-killer/9N673ZL1TCS7"
     },
@@ -4205,13 +4148,31 @@
         "releaseDate": "08/12/2013",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/peggle-2/BNCZHKWRZ7BR",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.63323.67897516232762656.798d5423-ae25-4369-b9f2-33205af62a6f.a1c62ace-b09e-417f-913e-528d6f4ca5e6?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.63323.67897516232762656.798d5423-ae25-4369-b9f2-33205af62a6f.a1c62ace-b09e-417f-913e-528d6f4ca5e6?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.22107.67897516232762656.798d5423-ae25-4369-b9f2-33205af62a6f.83cb696f-f678-4d37-85d1-80f6af20c9db?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/peggle-2/BNCZHKWRZ7BR"
+    },
+    {
+        "gameTitle": "Pentiment",
+        "gamePublisher": "Xbox Game Studios",
+        "gameDeveloper": "Obsidian Entertainment",
+        "gameGenres": [
+            "A\u00e7\u00e3o e aventura"
+        ],
+        "releaseDate": "15/11/2022",
+        "extraGameProperties": {
+            "isInGamePass": true,
+            "controllerSupport": true,
+            "touchControllerSupport": true
+        },
+        "xcloudUrl": "https://www.xbox.com/%s/play/games/pentiment/9NX6K9HN4F4K",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.25502.14431229486160986.b3655366-4704-41dd-bb1b-0ea3f2425df6.c8722871-999c-4dac-8691-5a97e501dcec?w=%i&format=jpg",
+        "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.50312.14431229486160986.b3655366-4704-41dd-bb1b-0ea3f2425df6.aefac356-4a3a-44b5-9544-78fd45cf702c?h=%i&format=jpg",
+        "storeUrl": "https://www.xbox.com/games/store/pentiment/9NX6K9HN4F4K"
     },
     {
         "gameTitle": "Perfect Dark Zero",
@@ -4224,13 +4185,49 @@
         "releaseDate": "10/08/2009",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/perfect-dark-zero/BZF7N4FQWHNR",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.21399.63613604984995316.d403620a-54b7-4a68-9850-e3bfda4c2552.9ba8a8e5-8c96-45b2-83cf-8eeef411eb81?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.21399.63613604984995316.d403620a-54b7-4a68-9850-e3bfda4c2552.9ba8a8e5-8c96-45b2-83cf-8eeef411eb81?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.35337.63613604984995316.d403620a-54b7-4a68-9850-e3bfda4c2552.bf1ef84f-cdda-4a06-9c9a-20c253d5bc91?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/perfect-dark-zero/BZF7N4FQWHNR"
+    },
+    {
+        "gameTitle": "Persona 5 Royal",
+        "gamePublisher": "SEGA",
+        "gameDeveloper": "ATLUS",
+        "gameGenres": [
+            "RPG"
+        ],
+        "releaseDate": "21/10/2022",
+        "extraGameProperties": {
+            "isInGamePass": true,
+            "controllerSupport": true,
+            "touchControllerSupport": true
+        },
+        "xcloudUrl": "https://www.xbox.com/%s/play/games/persona-5-royal/9NZDHXL9SJJ8",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.13393.14482474285447263.b2785fbb-9099-42c3-b705-629a79ac7e4a.2eb2f42a-78c6-49cb-bba9-f372747ecf47?w=%i&format=jpg",
+        "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.64063.14482474285447263.0a4055ed-9044-4c0c-abf5-292bb1bcb735.ba2d56c4-a5d7-48b3-9ecb-586e9379581d?h=%i&format=jpg",
+        "storeUrl": "https://www.xbox.com/games/store/persona-5-royal/9NZDHXL9SJJ8"
+    },
+    {
+        "gameTitle": "Phantom Abyss (Game Preview)",
+        "gamePublisher": "Devolver Digital",
+        "gameDeveloper": "Team WIBY",
+        "gameGenres": [
+            "A\u00e7\u00e3o e aventura"
+        ],
+        "releaseDate": "19/10/2022",
+        "extraGameProperties": {
+            "isInGamePass": true,
+            "controllerSupport": true,
+            "touchControllerSupport": false
+        },
+        "xcloudUrl": "https://www.xbox.com/%s/play/games/phantom-abyss-game-preview/9NCBTFHWJQNX",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.56251.13571270788175547.a0b8d076-db6b-4fbb-8482-0f78d6b14c6e.0418ee7e-5942-40fc-8e55-d5f42572d421?w=%i&format=jpg",
+        "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.8354.13571270788175547.a0b8d076-db6b-4fbb-8482-0f78d6b14c6e.b3e55109-6f71-45dc-996c-f5854ae43549?h=%i&format=jpg",
+        "storeUrl": "https://www.xbox.com/games/store/phantom-abyss-game-preview/9NCBTFHWJQNX"
     },
     {
         "gameTitle": "Phoenix Point",
@@ -4243,11 +4240,11 @@
         "releaseDate": "18/12/2019",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/phoenix-point/9P1P5Q3BNM7J",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.155.14507726714197033.ea391b48-d8cb-4724-a6cb-765168bd5161.3cfc32f8-f682-490e-9e59-cd6548a4c102?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.155.14507726714197033.ea391b48-d8cb-4724-a6cb-765168bd5161.3cfc32f8-f682-490e-9e59-cd6548a4c102?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.12076.14507726714197033.ea391b48-d8cb-4724-a6cb-765168bd5161.35842418-ad0c-4ee7-90b0-3326d4a835e5?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/phoenix-point/9P1P5Q3BNM7J"
     },
@@ -4261,11 +4258,11 @@
         "releaseDate": "11/03/2020",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/pikuniku/9N8WRDC25K6J",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.19280.14041044108785223.82419c4d-359a-436a-b07d-12cf7137d8fc.e3b3a42f-2c98-4caa-ac45-4ef73653930c?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.19280.14041044108785223.82419c4d-359a-436a-b07d-12cf7137d8fc.e3b3a42f-2c98-4caa-ac45-4ef73653930c?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.17854.14041044108785223.82419c4d-359a-436a-b07d-12cf7137d8fc.60e1cfd0-28c3-4e37-9abd-fb5498e2465d?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/pikuniku/9N8WRDC25K6J"
     },
@@ -4280,11 +4277,11 @@
         "releaseDate": "27/01/2020",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/pillars-of-eternity-ii-deadfire---ultimate-edition/9PJD2KMX7TZ6",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.10942.14218490899188575.a8c726f9-aa48-4378-bee2-0dffc21a7089.4b82a2de-3303-4ebf-aa9e-168b159f6207?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.10942.14218490899188575.a8c726f9-aa48-4378-bee2-0dffc21a7089.4b82a2de-3303-4ebf-aa9e-168b159f6207?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.18161.14218490899188575.a8c726f9-aa48-4378-bee2-0dffc21a7089.098005d1-269e-4f16-a67b-6669d7a9b05c?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/pillars-of-eternity-ii-deadfire---ultimate-edition/9PJD2KMX7TZ6"
     },
@@ -4299,11 +4296,11 @@
         "releaseDate": "28/08/2017",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/pillars-of-eternity-complete-edition/BS34VNW7H61F",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.15487.69508748727770428.7ce00ad4-485c-4664-819a-1d17af316267.8617d93c-eaf0-497c-b0f5-2f0e6102e9ff?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.15487.69508748727770428.7ce00ad4-485c-4664-819a-1d17af316267.8617d93c-eaf0-497c-b0f5-2f0e6102e9ff?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.29060.69508748727770428.7ce00ad4-485c-4664-819a-1d17af316267.f55434f9-2650-4cea-bf9a-a382615d7c8d?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/pillars-of-eternity-complete-edition/BS34VNW7H61F"
     },
@@ -4317,11 +4314,11 @@
         "releaseDate": "24/02/2014",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/plants-vs.-zombies-garden-warfare/BTJ0T8C04ZBV",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.57712.70921300667420253.8c8a7ac7-d0bd-46fb-a144-4c5ea316247c.b4f3a4a4-1e61-4685-8c7a-49ef7addd34c?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.57712.70921300667420253.8c8a7ac7-d0bd-46fb-a144-4c5ea316247c.b4f3a4a4-1e61-4685-8c7a-49ef7addd34c?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.355.70921300667420253.8c8a7ac7-d0bd-46fb-a144-4c5ea316247c.ca1b5fa7-17a6-4df0-90d8-883fee1d88f5?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/plants-vs.-zombies-garden-warfare/BTJ0T8C04ZBV"
     },
@@ -4335,11 +4332,11 @@
         "releaseDate": "18/10/2019",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/plants-vs.-zombies-battle-for-neighborville/C4HZC7LJG6PX",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.51083.66663660452837213.88feed53-4335-4b35-8a3a-476a0f0fd6ca.c4755ce8-cee4-4ca4-8f72-5e5bc6eae3de?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.51083.66663660452837213.88feed53-4335-4b35-8a3a-476a0f0fd6ca.c4755ce8-cee4-4ca4-8f72-5e5bc6eae3de?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.46421.66663660452837213.88feed53-4335-4b35-8a3a-476a0f0fd6ca.e0e7835b-39ff-4892-8010-fd049a22fd5c?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/plants-vs.-zombies-batalha-por-neighborville/C4HZC7LJG6PX"
     },
@@ -4353,13 +4350,32 @@
         "releaseDate": "22/02/2016",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/plants-vs.-zombies-garden-warfare-2/BNRH7BRC1D02",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.25500.68092588132505117.32378282-ea7e-40c4-a3a2-81703aa936d7.188e00bb-916b-4c65-9bb7-f1e5f2a829f9?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.25500.68092588132505117.32378282-ea7e-40c4-a3a2-81703aa936d7.188e00bb-916b-4c65-9bb7-f1e5f2a829f9?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.57302.68092588132505117.32378282-ea7e-40c4-a3a2-81703aa936d7.955d661f-9264-40d2-b964-35b3248f790d?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/plants-vs.-zombies-garden-warfare-2/BNRH7BRC1D02"
+    },
+    {
+        "gameTitle": "Potion Craft: Alchemist Simulator",
+        "gamePublisher": "tinyBuild",
+        "gameDeveloper": "niceplay games",
+        "gameGenres": [
+            "Desafios",
+            "Simula\u00e7\u00e3o"
+        ],
+        "releaseDate": "19/12/2021",
+        "extraGameProperties": {
+            "isInGamePass": true,
+            "controllerSupport": true,
+            "touchControllerSupport": false
+        },
+        "xcloudUrl": "https://www.xbox.com/%s/play/games/potion-craft-alchemist-simulator/9MW7WD7J3PPK",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.17503.13848482346226692.76b37d69-4a55-4077-ae36-a8f49e2ccf1c.8a22c7e1-e58b-4e64-aa00-5a039852fdd5?w=%i&format=jpg",
+        "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.15930.13848482346226692.76b37d69-4a55-4077-ae36-a8f49e2ccf1c.28213b1a-85fa-4728-9131-497e372e965c?h=%i&format=jpg",
+        "storeUrl": "https://www.xbox.com/games/store/potion-craft-alchemist-simulator/9MW7WD7J3PPK"
     },
     {
         "gameTitle": "Power Rangers: Battle for the Grid",
@@ -4371,11 +4387,11 @@
         "releaseDate": "25/03/2019",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/power-rangers-battle-for-the-grid/9P5VMG8D4P4B",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.60516.14636624242477201.684d5e4f-5586-4870-aa98-c0ce136ea8f4.4db9f25f-f2f2-4e72-a4d4-c4926ed6be0e?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.60516.14636624242477201.684d5e4f-5586-4870-aa98-c0ce136ea8f4.4db9f25f-f2f2-4e72-a4d4-c4926ed6be0e?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.59497.14636624242477201.684d5e4f-5586-4870-aa98-c0ce136ea8f4.83c30c3a-ed8d-464b-ba04-2ed35e59a8ce?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/power-rangers-battle-for-the-grid/9P5VMG8D4P4B"
     },
@@ -4389,11 +4405,11 @@
         "releaseDate": "14/07/2022",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/powerwash-simulator/9NHDJC0NW20M",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.60360.13631853399995812.7c8d5b79-31b8-46af-9143-329dfb697258.813651fd-f64f-4d40-a513-0584c3e6d6a5?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.60360.13631853399995812.7c8d5b79-31b8-46af-9143-329dfb697258.813651fd-f64f-4d40-a513-0584c3e6d6a5?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.42503.13631853399995812.7c8d5b79-31b8-46af-9143-329dfb697258.5f06d2e9-fb6d-4e93-8ad0-f271312d6941?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/powerwash-simulator/9NHDJC0NW20M"
     },
@@ -4407,11 +4423,11 @@
         "releaseDate": "04/05/2017",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/prey/BQMVWCMB8P59",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.11350.69234794984509140.ef3477c5-d6c7-4bd4-b5c7-7664d0e9e1be.56e552ce-a8b5-40eb-ae32-c7cefd77e069?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.11350.69234794984509140.ef3477c5-d6c7-4bd4-b5c7-7664d0e9e1be.56e552ce-a8b5-40eb-ae32-c7cefd77e069?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.55797.69234794984509140.ef3477c5-d6c7-4bd4-b5c7-7664d0e9e1be.22c0f565-2056-48ca-aa9c-85e280ff78f2?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/prey/BQMVWCMB8P59"
     },
@@ -4426,32 +4442,13 @@
         "releaseDate": "23/06/2021",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/prodeus/9MZRSLLWKWDV",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.13041.13864617007662897.01825ec5-fdc1-49fc-a5ac-f29f1860b3d2.b9a8b49a-0945-4ea8-a389-1cc6ba14ba50?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.34438.13864617007662897.03b7fc2a-1fd2-4210-88c8-75473c498d80.79d81c46-afa2-41ee-88a5-d7a4361649f5?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.9406.13864617007662897.01825ec5-fdc1-49fc-a5ac-f29f1860b3d2.4de0b1f4-bc29-45f6-9f06-cb0449d3d4d3?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/prodeus/9MZRSLLWKWDV"
-    },
-    {
-        "gameTitle": "Project Wingman",
-        "gamePublisher": "Humble Games",
-        "gameDeveloper": "Sector D2",
-        "gameGenres": [
-            "A\u00e7\u00e3o e aventura",
-            "Corrida e voo"
-        ],
-        "releaseDate": "28/07/2021",
-        "extraGameProperties": {
-            "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
-        },
-        "xcloudUrl": "https://www.xbox.com/%s/play/games/project-wingman/9NQ73XB1Q5ZG",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.22923.13774735967551951.4e47740d-df56-4f79-8338-58493ef3afb7.b580b6f9-fd70-4d43-8e6b-7f37ba6fa349?w=%i&h=%i",
-        "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.33562.13774735967551951.4e47740d-df56-4f79-8338-58493ef3afb7.da8b2b6f-1ef1-40fe-9e64-435c8e5c4c73?h=%i&format=jpg",
-        "storeUrl": "https://www.xbox.com/games/store/project-wingman/9NQ73XB1Q5ZG"
     },
     {
         "gameTitle": "Psychonauts",
@@ -4464,11 +4461,11 @@
         "releaseDate": "31/03/2005",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/psychonauts/C5HHPG1TXDNG",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.18666.67203256484290113.fa47f972-08bc-4a6e-a86b-1114b30416e6.4bca37aa-490d-47c6-9385-dd7618a5c6eb?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.18666.67203256484290113.fa47f972-08bc-4a6e-a86b-1114b30416e6.4bca37aa-490d-47c6-9385-dd7618a5c6eb?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.20895.67203256484290113.f0f8de04-809c-4624-894c-af72ab8f4440.81fd8bc3-e4d4-42e3-8753-feecdc73c7e4?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/psychonauts/C5HHPG1TXDNG"
     },
@@ -4483,11 +4480,11 @@
         "releaseDate": "24/08/2021",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/psychonauts-2/9NBR2VXT87SJ",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.17302.13578175979543723.424401c3-5602-4e35-abfc-c00f9156296a.e6d1e593-0006-4b73-886e-dd37b6626198?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.17302.13578175979543723.424401c3-5602-4e35-abfc-c00f9156296a.e6d1e593-0006-4b73-886e-dd37b6626198?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.38893.13578175979543723.424401c3-5602-4e35-abfc-c00f9156296a.e5bedcb0-57fa-41f5-b177-a84aec587699?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/psychonauts-2/9NBR2VXT87SJ"
     },
@@ -4502,11 +4499,11 @@
         "releaseDate": "20/01/2022",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/pupperazzi/9P34LH5ZWBVG",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.9496.14545000756331709.fe0b8e3c-108f-4f54-a7d0-a2b1eded6bbe.eabd1905-e86b-417c-8694-e08cb97d72b2?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.9496.14545000756331709.fe0b8e3c-108f-4f54-a7d0-a2b1eded6bbe.eabd1905-e86b-417c-8694-e08cb97d72b2?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.63128.14545000756331709.fe0b8e3c-108f-4f54-a7d0-a2b1eded6bbe.55668df5-9844-4fa3-81df-ff8b50c38c48?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/pupperazzi/9P34LH5ZWBVG"
     },
@@ -4520,11 +4517,11 @@
         "releaseDate": "18/08/2021",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/quake/9P1Z43KRNQD4",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.31797.14497943460299347.3ad06bb4-d442-43a2-99e0-f41399a5b03e.d1944e73-cd9b-4fd2-914c-4a4c3db63b39?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.31797.14497943460299347.3ad06bb4-d442-43a2-99e0-f41399a5b03e.d1944e73-cd9b-4fd2-914c-4a4c3db63b39?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.1853.14497943460299347.3ad06bb4-d442-43a2-99e0-f41399a5b03e.cd82a6c1-63e8-44e3-b84a-174ae43f0d57?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/quake/9P1Z43KRNQD4"
     },
@@ -4539,11 +4536,11 @@
         "releaseDate": "03/10/2011",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/rage/BR27BSZ2M3SR",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.51318.68925464159691452.a2903bed-8f56-422f-b4a8-81cca9a4bf93.ddfde01b-109b-479a-83d4-428746a31c96?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.51318.68925464159691452.a2903bed-8f56-422f-b4a8-81cca9a4bf93.ddfde01b-109b-479a-83d4-428746a31c96?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.61825.68925464159691452.a2903bed-8f56-422f-b4a8-81cca9a4bf93.6e1df128-dd81-4826-9673-1e056cb1d163?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/rage/BR27BSZ2M3SR"
     },
@@ -4558,11 +4555,11 @@
         "releaseDate": "13/05/2019",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/rage-2/C2DCJ95ZXBMS",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.25597.65377716030309997.4ce8fd57-e617-46e7-9d4f-e8b49f4d07ef.8032cd3b-4de6-4872-8e49-32f042b5a139?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.25597.65377716030309997.4ce8fd57-e617-46e7-9d4f-e8b49f4d07ef.8032cd3b-4de6-4872-8e49-32f042b5a139?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.25179.65377716030309997.4ce8fd57-e617-46e7-9d4f-e8b49f4d07ef.c6a45f3d-a294-4a95-95e6-bcb8bab2ffec?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/rage-2/C2DCJ95ZXBMS"
     },
@@ -4577,32 +4574,32 @@
         "releaseDate": "25/04/2022",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/research-and-destroy/9NNZJ389GSW2",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.16507.13733601761067019.0d7183b3-e7b3-48cd-9ed1-a4a0444fb623.88d187de-1ddd-4b84-abba-68689e8a3c09?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.16507.13733601761067019.0d7183b3-e7b3-48cd-9ed1-a4a0444fb623.88d187de-1ddd-4b84-abba-68689e8a3c09?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.50804.13733601761067019.0d7183b3-e7b3-48cd-9ed1-a4a0444fb623.b09cbb60-6e7b-4165-8f7e-34866ad02323?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/research-and-destroy/9NNZJ389GSW2"
     },
     {
-        "gameTitle": "Corre com o Ryan",
-        "gamePublisher": "Outright Games",
-        "gameDeveloper": "3D Clouds",
+        "gameTitle": "Rainbow Billy: The Curse of the Leviathan",
+        "gamePublisher": "Skybound Games",
+        "gameDeveloper": "ManaVoid Entertainment",
         "gameGenres": [
-            "Fam\u00edlia e crian\u00e7as",
-            "Corrida e voo"
+            "A\u00e7\u00e3o e aventura",
+            "RPG"
         ],
-        "releaseDate": "31/10/2019",
+        "releaseDate": "05/10/2021",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
-        "xcloudUrl": "https://www.xbox.com/%s/play/games/race-with-ryan/9N1JLJR48FBG",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.57033.13904742134987369.fd462387-ec74-4545-a15b-c5500d99e660.e38df00e-9a2f-48ad-8728-3af751b1817a?w=%i&h=%i",
-        "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.48112.13904742134987369.fd462387-ec74-4545-a15b-c5500d99e660.b73a1434-ca86-40f6-bc7a-8bb840ff845b?h=%i&format=jpg",
-        "storeUrl": "https://www.xbox.com/games/store/corre-com-o-ryan/9N1JLJR48FBG"
+        "xcloudUrl": "https://www.xbox.com/%s/play/games/rainbow-billy-the-curse-of-the-leviathan/9PMGFL6KM0T2",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.29645.14293952320453711.7b0495b8-be6b-4fbc-9d4c-95bf880b7637.aee8335d-6c09-4147-bf12-78be5fd5ecb2?w=%i&format=jpg",
+        "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.14520.14293952320453711.7b0495b8-be6b-4fbc-9d4c-95bf880b7637.07a5a89a-6176-4c24-bed7-c0b61b4c42a9?h=%i&format=jpg",
+        "storeUrl": "https://www.xbox.com/games/store/rainbow-billy-the-curse-of-the-leviathan/9PMGFL6KM0T2"
     },
     {
         "gameTitle": "ReCore",
@@ -4614,11 +4611,11 @@
         "releaseDate": "13/09/2016",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/recore/9NBLGGH1Z6FQ",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.34726.13510798886186651.76cfa366-2ebc-44ea-984f-6bf954e4c742.3a35291d-d9c2-451a-ab83-e043aba71471?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.34726.13510798886186651.76cfa366-2ebc-44ea-984f-6bf954e4c742.3a35291d-d9c2-451a-ab83-e043aba71471?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.25983.13510798886186651.afa678b2-6141-401c-868d-2c30769054ea.fbd2b41c-ffb2-4148-816e-a140d005237b?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/recore/9NBLGGH1Z6FQ"
     },
@@ -4633,32 +4630,32 @@
         "releaseDate": "19/08/2021",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/recompile/9PDRJWHBSK88",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.7926.14144555811461915.e7755e4b-3306-4aad-9430-4916b54d99c2.b1011be9-3984-4479-9824-34a919e4d224?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.7926.14144555811461915.e7755e4b-3306-4aad-9430-4916b54d99c2.b1011be9-3984-4479-9824-34a919e4d224?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.62031.14144555811461915.e7755e4b-3306-4aad-9430-4916b54d99c2.e28fe86b-b80a-4096-aaef-4230ab4f5808?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/recompile/9PDRJWHBSK88"
     },
     {
-        "gameTitle": "Record of Lodoss War-Deedlit in Wonder Labyrinth-",
-        "gamePublisher": "PLAYISM",
-        "gameDeveloper": "Team Ladybug, WSS Playground",
+        "gameTitle": "Return to Monkey Island",
+        "gamePublisher": "Devolver Digital",
+        "gameDeveloper": "Terrible Toybox",
         "gameGenres": [
             "A\u00e7\u00e3o e aventura",
-            "Plataforma"
+            "Desafios"
         ],
-        "releaseDate": "16/12/2021",
+        "releaseDate": "08/11/2022",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
-        "xcloudUrl": "https://www.xbox.com/%s/play/games/record-of-lodoss-war-deedlit-in-wonder-labyrinth-/9NRBH9HS807L",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.10926.14386120322819171.2fc4013e-47df-4a11-be12-356830abf1b1.0cef0785-64a2-402f-ab1b-cc19dfd1f741?w=%i&h=%i",
-        "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.51415.14386120322819171.2fc4013e-47df-4a11-be12-356830abf1b1.c0812796-7c40-41e8-b774-fc7504dfa489?h=%i&format=jpg",
-        "storeUrl": "https://www.xbox.com/games/store/record-of-lodoss-war-deedlit-in-wonder-labyrinth-/9NRBH9HS807L"
+        "xcloudUrl": "https://www.xbox.com/%s/play/games/return-to-monkey-island/9PC4R8N1N2T6",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.41133.14176324986442763.11fa95be-f98f-4be1-a416-9571cd1286df.bbee7d3d-c543-476f-8cfe-4e58d8977b81?w=%i&format=jpg",
+        "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.42334.14176324986442763.11fa95be-f98f-4be1-a416-9571cd1286df.68d734ce-26f1-41b0-a62d-24bcc0059d09?h=%i&format=jpg",
+        "storeUrl": "https://www.xbox.com/games/store/return-to-monkey-island/9PC4R8N1N2T6"
     },
     {
         "gameTitle": "Road 96",
@@ -4671,11 +4668,11 @@
         "releaseDate": "14/04/2022",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/road-96/9NVBKDF85W8T",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.37271.14401791124788682.a53b3c8e-a868-4dbf-845f-6db87942340c.99d9dd76-ba11-4a9f-91ec-3068355983d4?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.37271.14401791124788682.a53b3c8e-a868-4dbf-845f-6db87942340c.99d9dd76-ba11-4a9f-91ec-3068355983d4?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.46600.14401791124788682.93615ee9-0e7c-43f8-b866-893bdb3aeb43.3e813e23-8ad9-4054-b66a-9fa7925ae6a1?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/road-96/9NVBKDF85W8T"
     },
@@ -4690,12 +4687,12 @@
         "releaseDate": "01/12/2021",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/rubber-bandits/9PL36RW9ZTPW",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.26161.14250942844501146.afc9b68d-bea3-4e5a-8e85-e060a99b7a83.c11680cb-1676-4bec-ab7d-ca262614f3fd?w=%i&h=%i",
-        "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.48562.14250942844501146.afc9b68d-bea3-4e5a-8e85-e060a99b7a83.6c7609e8-dcee-40a3-a94c-5fbe2de6dc5b?h=%i&format=jpg",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.371.14250942844501146.365d5888-8ee7-47c6-a0aa-4bc551a341b7.0a42741e-b253-4779-ad12-3d33dba3fc7e?w=%i&format=jpg",
+        "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.55816.14250942844501146.fc1a29cf-944f-4d70-87bb-e25be21ff9a4.c296d86b-cd21-4e1a-b27b-657b968993ee?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/rubber-bandits/9PL36RW9ZTPW"
     },
     {
@@ -4708,11 +4705,11 @@
         "releaseDate": "31/10/2017",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/rush-a-disneypixar-adventure/9P3PL76N0KWZ",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.54193.14538559069860396.375a4717-d4e1-4c14-b278-f4787b52d21a.8ccfcf77-d0bc-4895-a1e6-f70806a4a045?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.54193.14538559069860396.375a4717-d4e1-4c14-b278-f4787b52d21a.8ccfcf77-d0bc-4895-a1e6-f70806a4a045?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.5896.14538559069860396.1d93e2fd-2dab-4371-9ba3-622feb19d443.794b050e-1acc-4b57-a61d-eb1954b202d2?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/rush-a-disney-%E2%80%A2-pixar-adventure/9P3PL76N0KWZ"
     },
@@ -4727,13 +4724,49 @@
         "releaseDate": "24/06/2021",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/scarlet-nexus/9N9RMHTJX41P",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.11684.13531489140319204.2e417a21-11c1-4902-a4f1-8ac2c24c42b2.db8694a7-65f4-4932-ad63-c240816b2f95?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.11684.13531489140319204.2e417a21-11c1-4902-a4f1-8ac2c24c42b2.db8694a7-65f4-4932-ad63-c240816b2f95?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.24095.13531489140319204.2e417a21-11c1-4902-a4f1-8ac2c24c42b2.330b5343-f5a6-4d41-b88a-e550457cdee0?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/scarlet-nexus/9N9RMHTJX41P"
+    },
+    {
+        "gameTitle": "SIGNALIS",
+        "gamePublisher": "Humble Games",
+        "gameDeveloper": "rose-engine",
+        "gameGenres": [
+            "A\u00e7\u00e3o e aventura"
+        ],
+        "releaseDate": "27/10/2022",
+        "extraGameProperties": {
+            "isInGamePass": true,
+            "controllerSupport": true,
+            "touchControllerSupport": false
+        },
+        "xcloudUrl": "https://www.xbox.com/%s/play/games/signalis/9PLF2RS7JRZL",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.11569.14318995650611811.0f3dee8c-81a0-462b-ad92-c6b77b6038ef.a4d6d11e-2062-44e6-8172-ab61a4a7ea69?w=%i&format=jpg",
+        "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.27372.14318995650611811.0f3dee8c-81a0-462b-ad92-c6b77b6038ef.ac88cf67-ad2a-4343-af96-cf15f4ed3ab8?h=%i&format=jpg",
+        "storeUrl": "https://www.xbox.com/games/store/signalis/9PLF2RS7JRZL"
+    },
+    {
+        "gameTitle": "SOMA",
+        "gamePublisher": "Frictional Games",
+        "gameDeveloper": "Frictional Games",
+        "gameGenres": [
+            "A\u00e7\u00e3o e aventura"
+        ],
+        "releaseDate": "30/11/2017",
+        "extraGameProperties": {
+            "isInGamePass": true,
+            "controllerSupport": true,
+            "touchControllerSupport": true
+        },
+        "xcloudUrl": "https://www.xbox.com/%s/play/games/soma/C23M2TC1ZFPJ",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.37481.65760911830429861.7b27281f-47aa-4d50-936b-ec0d2edf2e0a.d01e5549-2799-49ca-855b-bb460e52bf54?w=%i&format=jpg",
+        "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.43793.65760911830429861.7b27281f-47aa-4d50-936b-ec0d2edf2e0a.60f8b600-77f7-4d2d-82e7-54b467a9a3e9?h=%i&format=jpg",
+        "storeUrl": "https://www.xbox.com/games/store/soma/C23M2TC1ZFPJ"
     },
     {
         "gameTitle": "STAR WARS Jedi: Fallen Order\u2122",
@@ -4745,11 +4778,11 @@
         "releaseDate": "14/11/2019",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/star-wars-jedi-fallen-order/C2CSDTSCBZ0C",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.52300.65392999590663672.028b6875-f925-4d40-b3a1-e44db3b4fa32.7bcb3d0f-46fc-43ea-84d1-031bd0817da2?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.52300.65392999590663672.028b6875-f925-4d40-b3a1-e44db3b4fa32.7bcb3d0f-46fc-43ea-84d1-031bd0817da2?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.16830.65392999590663672.028b6875-f925-4d40-b3a1-e44db3b4fa32.cc4f831d-718e-4771-9e6e-1a83cea24896?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/star-wars-jedi-fallen-order/C2CSDTSCBZ0C"
     },
@@ -4763,11 +4796,11 @@
         "releaseDate": "16/11/2017",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/star-wars-battlefront-ii/C0GWTPD0S8S1",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.57852.64256825846959382.44b5bc43-437a-4414-83ca-b41ba9e7764a.6845daab-0518-41a7-b14a-525d8d79f571?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.57852.64256825846959382.44b5bc43-437a-4414-83ca-b41ba9e7764a.6845daab-0518-41a7-b14a-525d8d79f571?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.12447.64256825846959382.44b5bc43-437a-4414-83ca-b41ba9e7764a.0e2ce787-008a-4571-bf11-a161817b1e01?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/star-wars-battlefront-ii/C0GWTPD0S8S1"
     },
@@ -4782,11 +4815,11 @@
         "releaseDate": "02/10/2020",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/star-wars-squadrons/BV9CWVQWNS4P",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.49564.71371953440216666.508e0708-a814-4f11-8420-5f620fd8ce09.6a0698b5-ba6b-4f01-8338-015ad9537a91?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.49564.71371953440216666.508e0708-a814-4f11-8420-5f620fd8ce09.6a0698b5-ba6b-4f01-8338-015ad9537a91?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.25186.71371953440216666.508e0708-a814-4f11-8420-5f620fd8ce09.60cc5eb5-7852-4e4c-8558-45342330e331?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/star-wars-squadrons/BV9CWVQWNS4P"
     },
@@ -4800,11 +4833,11 @@
         "releaseDate": "14/10/2022",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/scorn/9NM3TNRPQXLR",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.51381.13699799412731780.9f7b812e-456c-430e-8cec-380f1ca9e4a2.dd9f4725-f6e0-4fe4-9484-9d5f22682786?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.51381.13699799412731780.9f7b812e-456c-430e-8cec-380f1ca9e4a2.dd9f4725-f6e0-4fe4-9484-9d5f22682786?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.16661.13699799412731780.1afb5b8c-d3cf-40b3-aa5e-f5e01adefd6c.71e32c0e-4c10-4a4b-a813-3478373b1769?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/scorn/9NM3TNRPQXLR"
     },
@@ -4818,32 +4851,13 @@
         "releaseDate": "20/03/2018",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/sea-of-thieves/9P2N57MC619K",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.21319.14554784103656548.6c0bfca6-ceff-4368-9bde-2fe50f344136.c8d6c767-18a9-49cd-b9ca-4cc9a3a336e5?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.21319.14554784103656548.6c0bfca6-ceff-4368-9bde-2fe50f344136.c8d6c767-18a9-49cd-b9ca-4cc9a3a336e5?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.16127.14554784103656548.5229b523-ba31-4e1e-8b9b-af4211062227.7176a52d-9b92-4c1b-b756-af25abfa99c5?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/sea-of-thieves/9P2N57MC619K"
-    },
-    {
-        "gameTitle": "Second Extinction\u2122 (Game Preview)",
-        "gamePublisher": "Systemic Reaction\u2122",
-        "gameDeveloper": "Systemic Reaction\u2122",
-        "gameGenres": [
-            "A\u00e7\u00e3o e aventura",
-            "Jogos de tiros"
-        ],
-        "releaseDate": "31/12/2798",
-        "extraGameProperties": {
-            "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
-        },
-        "xcloudUrl": "https://www.xbox.com/%s/play/games/second-extinction-game-preview/9P9JZLNFQ9PT",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.42521.14137276003875252.d1d6dd04-81e9-424d-a1b6-7a81e52dfeef.e61cd8b8-4b66-4175-b861-651aa5adb79a?w=%i&h=%i",
-        "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.54318.14137276003875252.d1d6dd04-81e9-424d-a1b6-7a81e52dfeef.63325c2c-d76a-4c29-bc75-24d79c3b2ae0?h=%i&format=jpg",
-        "storeUrl": "https://www.xbox.com/games/store/second-extinction-game-preview/9P9JZLNFQ9PT"
     },
     {
         "gameTitle": "Secret Neighbor",
@@ -4855,12 +4869,12 @@
         "releaseDate": "23/10/2019",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/secret-neighbor/9P7GBPGT90L3",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.19855.14605254180386304.db0b6acf-32d5-404e-961c-57a78494928f.40fda6df-25aa-490f-ac84-95999557275c?w=%i&h=%i",
-        "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.46974.14605254180386304.db0b6acf-32d5-404e-961c-57a78494928f.afba8228-587f-49de-aba5-64dd2f3d2b98?h=%i&format=jpg",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.39065.14605254180386304.0cf6e445-2a31-405b-8616-b2d4517f1441.c0674226-b4a5-4a29-a44a-7ff28f193f49?w=%i&format=jpg",
+        "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.47680.14605254180386304.0cf6e445-2a31-405b-8616-b2d4517f1441.815fb757-30f4-40e4-823a-1fa4c63e4059?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/secret-neighbor/9P7GBPGT90L3"
     },
     {
@@ -4874,11 +4888,11 @@
         "releaseDate": "06/12/2021",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/serious-sam-4/9N5521ZQMQMJ",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.47130.13969859700306157.e45e75fc-cfcd-4dcd-967b-c356d04848f4.096a5307-9c8a-4582-a415-9c38230bfbae?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.47130.13969859700306157.e45e75fc-cfcd-4dcd-967b-c356d04848f4.096a5307-9c8a-4582-a415-9c38230bfbae?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.39832.13969859700306157.e45e75fc-cfcd-4dcd-967b-c356d04848f4.ae7b4d9b-dcf9-4f3b-8c35-2ace01d36092?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/serious-sam-4/9N5521ZQMQMJ"
     },
@@ -4893,11 +4907,11 @@
         "releaseDate": "21/06/2022",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/shadowrun-returns/9N6PHQ93Z451",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.55573.14009816262451240.3e3808e2-1e94-4457-b77b-8450027fa25a.12a5baa8-dec7-4fe0-ba05-3b068d35b733?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.55573.14009816262451240.3e3808e2-1e94-4457-b77b-8450027fa25a.12a5baa8-dec7-4fe0-ba05-3b068d35b733?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.13787.14009816262451240.3e3808e2-1e94-4457-b77b-8450027fa25a.67b4a55c-423d-454c-9599-1d6de0439357?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/shadowrun-returns/9N6PHQ93Z451"
     },
@@ -4912,11 +4926,11 @@
         "releaseDate": "21/06/2022",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/shadowrun-dragonfall---director's-cut/9PKJTP6DTND3",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.13822.14266045593708116.bcec8af8-9570-471e-aa75-827739f252f6.a3f2fd69-c499-4cb1-9860-59c5d1d91518?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.13822.14266045593708116.bcec8af8-9570-471e-aa75-827739f252f6.a3f2fd69-c499-4cb1-9860-59c5d1d91518?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.27671.14266045593708116.f6624cf3-4372-4621-81b9-875cd02d9c6f.b2a97150-68d6-4e16-b59a-15c696c6f29b?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/shadowrun-dragonfall---director's-cut/9PKJTP6DTND3"
     },
@@ -4931,11 +4945,11 @@
         "releaseDate": "21/06/2022",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/shadowrun-hong-kong---extended-edition/9N7V5R3VLMJZ",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.24618.14057715674749150.d6d6bc42-2e9e-4eb2-a96b-1baf2eaca60b.63cc5402-85b3-4a0a-9919-78cda3d9071c?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.24618.14057715674749150.d6d6bc42-2e9e-4eb2-a96b-1baf2eaca60b.63cc5402-85b3-4a0a-9919-78cda3d9071c?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.46434.14057715674749150.c2590a77-4cfa-4f3f-9a45-cba33421b4a9.7a688afd-c22f-41c9-9862-0282eec55b6b?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/shadowrun-hong-kong---extended-edition/9N7V5R3VLMJZ"
     },
@@ -4950,11 +4964,11 @@
         "releaseDate": "16/03/2022",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/shredders/9N4PGNQQ7ZFK",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.59364.13979077126806036.96d207e3-0572-4ada-b872-bc0f9f1ce219.652e1b3c-1da3-4076-afc2-a639fc83ec42?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.59364.13979077126806036.96d207e3-0572-4ada-b872-bc0f9f1ce219.652e1b3c-1da3-4076-afc2-a639fc83ec42?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.19464.13979077126806036.fde8a9af-c12a-4674-9134-9644f5e2be50.e3ba7362-e83c-4a60-b1a0-e9af1245644d?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/shredders/9N4PGNQQ7ZFK"
     },
@@ -4968,11 +4982,11 @@
         "releaseDate": "22/09/2014",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/skate-3/BNKDKQXMXRR2",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.25388.68005754082254855.39795a60-73cf-4461-87d9-7f112c30c43c.7d99d88b-5b61-4951-9de7-34e5ddad1df2?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.25388.68005754082254855.39795a60-73cf-4461-87d9-7f112c30c43c.7d99d88b-5b61-4951-9de7-34e5ddad1df2?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.57264.68005754082254855.39795a60-73cf-4461-87d9-7f112c30c43c.a9fe1ef9-f8df-4ac1-89c1-cbd3a5f1b852?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/skate-3/BNKDKQXMXRR2"
     },
@@ -4987,11 +5001,11 @@
         "releaseDate": "21/10/2021",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/skul-the-hero-slayer/9NW4Z3HPJVKW",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.47199.14456124164135894.3812513e-617a-4507-a78c-e1b3d444d32a.6eb602b5-ae29-4ed6-a518-a3129440840a?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.47199.14456124164135894.3812513e-617a-4507-a78c-e1b3d444d32a.6eb602b5-ae29-4ed6-a518-a3129440840a?w=%i&format=jpg",
         "gameImageUrl": "https:AAAAIGZ0eXBhdmlmAAAAAGF2aWZtaWYxbWlhZk1BMUIAAADybWV0YQAAAAAAAAAoaGRscgAAAAAAAAAAcGljdAAAAAAAAAAAAAAAAGxpYmF2aWYAAAAADnBpdG0AAAAAAAEAAAAeaWxvYwAAAABEAAABAAEAAAABAAABGgAAEvMAAAAoaWluZgAAAAAAAQAAABppbmZlAgAAAAABAABhdjAxQ29sb3IAAAAAamlwcnAAAABLaXBjbwAAABRpc3BlAAAAAAAAA8AAAAIcAAAAEHBpeGkAAAAAAwgICAAAAAxhdjFDgQQMAAAAABNjb2xybmNseAABAAEAAYAAAAAXaXBtYQAAAAAAAAABAAEEAQKDBAAAEvttZGF0EgAKChkme/hvogICAwgy4iUQ3ADDDDEAgkD0uJloL/IWGSkZEGwVSjLSqtILBrBvhRKu/6G75+rbd8CBGI6qRciStZmCl66cJxpKxnVsXUEnyN2OBSyFEgAn/xbYB63xcP1qMhb4z6vBJAzl22YDQxowxfnTTsJvEc7jHtpQtRO8zXIkxH5FOSkKZgnLoocuWmsyLCeBMQ/Y2CfCcXFBGLAL5Od9gZwYKKyLD2DkdggKfyFlsS9eYivYaecJ6dPwWnfq/jtOpSva5kgf4m90Tbk18tvO36SZdWw9bcVSYZMbXpUICh1L8i4ikoY8o4EBlbTnA+dBj1gKRSm+ydBSv30aoFTZDhrS879mxefVyRJgymecRhfHObIgpnhmmih/EVR6b3ywnBHOPzV9DG7idFy3f3ev01QzSIiAoMO7sX+R9juuNPuo/T3GmNt5vXMctoZgStYZ6N8M/hqa7OFLHMSPVc0KsW88yMb9lCFAdl3dus/YG5dpyV356GImj5iuvb0AdBMG1KNqHSLTMlSb6W9jpbIimiNTSAr3A03SPa3tV0YoqN72wMto6z33nyD9Rxtjr+eV+xarO+0XzL6gGhvxYWvOOCnEIkEuF1LFQsqbFhxel2CXIGQJ685Y94pmXVjFIeAk9m7UlYRN4YsvYEqh3atflxyBVYG3LLJejL/l/2rIsSe1qtP3AQfAFbGjVSt42P6iQhIEM9Ft7Yl0vnW65zsbZcOILNQ93ecTby3bvvN00klgQqfiMajeH/Us5xuX+Fz+AAAXqja8OB1suZ3rnbL+Y6HRCga4bfyfZMnaCOp/FvrENDdWqciuBX2htYA+0wjgksZ9wQm9VdoPrN80Mw1PIlz0Z/zcqgSW2pH3pLUI7ZuoFvhNP3WEAw1csgbk0hmeAp4PLUNhz/M3/y0mWYF1I1y1grofKEHSZwxPg1wcB/kI/kVBt5OMrGlfcbmHogib+dQHwch/Lnzc1Uto4Kh3Kukat+ArF8vAnP2EO5Ko2jQYnC6/b/W00k9DogEiJQKBsv410VrDAiW/lCBAvqwJMD+f9PZcxc0/zrirz/5O+I2iREATjE1TD68QWnha05B1w+dWFkPplo5UcuKkTySgri3pdDmIbasDt3nYFiD58zL8O3/2TmbULUf+DfPNkBzGtUFbaL206BI0SyiiEcDLqMxY3GCBvl5jrPID6ctR9H/8xhRZ+p3sA2UgsQCYL7O/dxR57FIerX3l7QOpmkkVZLkc8Zq3bHCHrO2g+P8SV0gpdZNR7Jt6dUSPZQXsIWXInEwtha+SizSJRFIT82YJMwhQRM7RtrfjwwNt/disBRQZ4Fgt3yvbVf/gOXE9+a2Oj5UV/fs9/6R/sWA8ulTq2iPfuXWnVoYq8bmaeRgRg2mWOeotIxjl5Nvz7vbNjRwy2JGhwr7Tw4yf6A5UNNv1ODQXA4Lq92+fQ83EWPubkOw+ZsBN18Iw5Nawbgm0LmT0YByqkqSQQABykNU1MSqYcoGSGGi720FvEHyUinYPhlsmkef0Emj1kK7R08HmEflnpIGV/eMYgYnrxeA68qGGAU1VHWCsDd7nKAolXlOJJDecwr75P2AoaXRdIGJj9bCpFDjMIA69rlnBhsVoO3DQcA5EgwjMJiehDEJIi5ZDW4BKrPiVZhbEOKBFi9j1lHT0Q02NSsgoOcY6DUkkvCys7hvEWLHK603KbJgvLIix6SeTc3Z85diDrzyOPoB3FpwWrGwDYI6qtXMUMoWGHiqF8ndKfRMxapILkDKEwEl1TcLY9uYPTx7MBB1cYJEO26/TEyQrDom/t9AxzbvchhHn/s4cT6NIWKye5/Ax3/lQprrRSKHHhUXgZDHU8b55cGJvIOaPAAVU/OWSXvFJaJg7NAF59KLTs/QaQOY+XOkOrVckngjWfqptMTt7F14By9thqXTzB2yJw+26DbaRf8Q/AObcca5Bujoh9YH1SL3BlPElHhONTN78REUNH4JqSibgmMAaxDCTxjLLPOydVstEunniC6kySY6sZxtig3L885KY7seoxlxXtMEmvXSSaJfiV/r6Cgfe7IfRtWAxdpaCi3VGllDHD9H0b5VHvk3QfeTlXyzoXRoecZmoC/GmCplwCFBjViOuEVsacMcqtJYcF57qAAYOYSrXXKvRkG6mwvF1QbaLRHLANnBJ/OSFVOt93MNLafQ11pJEa2qfoSm71MOy7lpMgLQ5Qqf/DA9I16DUQVxqEAsu48k4kKxrsIHMObWEQmWX4wrk44aebulLGATBlxMMBKF1kkv3pd68mZcRezooop+fh7/9LPbUurm7s8dxk8kpvYqFUkIpF8sLiOnmyEB/NyBlurTgV/yQD+zA0BLm4nO6QHxWDrfV41ZQAYghz/AXP9ikxlvHM6Xv/LMjKc1isyxMTLSRwIa2IoxCaFv6eWsnxFFpFSAejBD4t16+EJuQchYOrQ6Vt/n/al/Z/onRaZ+e1/SSYCegCrlMzjpolzqZrCjX3vaGI+RuQ7f8u0Gnp8ij6KNnPPWJA0gPv5fSUav+D8Rhb4zPmIfYcmvr8z0apIXbNA9cO47fJNYJ6CqHXTukpV4YarR9Q48tUPUKbi5q1fuEE9gKSRXa3GW4sd9EiLsOST/CsR10ouAUXVmcao8FNXgzNw3fCpvdk4EwNbsAY4po7KSRNV57rVAqY6Q/2xPRI9uvqFIEQuepUwAQoQH98uNlXz6ZO9OnKc/GZSoKs94LN8IuyPMTrDjoILvBeH8Ob9B3BNq4OwgLDL4hKq4zwIQMVms4CJDk311zy37RkS5fxDLddfw1A0s1fOsVwr63QeyllZpq8vTWZZWZBNICezB1+v4QiS4KHaJJyHlnbVeJB1WrUmqvSYKMm3SV2c2XtQoNW5A4ccQI3LqT5v9I/Z3ATGDMov35j95IxCx9ArKxYPt+JlHxesbpLXYXijz8XlVmoBlI+veHUAX+qhPX2ktDz+yabpDom/avarmkPt3ve2es+zyA9MfMZd7nIximUgqZNEBoKhtq56jAzx5iwblt1AXVaME1qdSgrFNREt+7TRInJ7VkzYeSDiH6i0dKe+tTgxejF6CZE5IU8KYYZABhY3kC/oaybwH1+ahxKLz3+FDUZH/XP2vjY8DIhq4dVuBJpHvadH2mE7nrVHsITPfdqtqpBd6fFPRqXlW+QuD0lRCa8ocnNqpdhSIqoC9SqdrwLtQIqAbj7AYNVhNp9HnJd5BSBdSskuCG/SBGVLeh+Mbb05+E9oU0VQb2DJNKUm5wsW/wR9B/JNSVej5stWVqomlHN+ZG7oL4kKM1ftyDqY/5/NoeDgpFSwyqsa1/M+IVnlK/jFmnBA0wxz5phnzmsCvFwO69Yw3o11fEw4/59zhO75WYX7AMrq3XGt8RL/kAKJzfChOYnxmJpe2YOKiU/MbxhKFxnqt4/aA8nGjOz80PBaFx1B/BqBriBmg1Cdvdtt668/GQufmcALI5esAobu0QPFaT9mWtbYUlxPfp1vP9XraiyWL2OQ897rcjBBBgDo6iw5NJjFF+kzx9UvZEzNF1ZEvYaksTNzP94HXgx6IukDGf5MKwUsubgmn0ozatMNqi1ECQnsf1xkmnTT/wa0i48JJeCf1QBps2b88aw4ZMwq8OEbFqngpuqq/cUvQkP8mX84ABfcoEWjDdPaKkrEquOXbDf/7wddVo7JgKZvcdXFhtmp5mSLXUal9hTDVvcpFjxL111GCryDjLkzajV3N0mO5T1feP1XPIPeIbvX/Dm4LSSEhBgq8WcmviCbHhkVZcYZAR0DeCfaGH4gkTKS3u2tGZWEFVMQDhqm/fZRNroLa7mrd62bJkZnyMUwsDOxUnCu0H0pA3DgQLsj79aYMgzBDGbJIIHl79PFzRULrJWaUP7Hr2LRBCgXXVNY7/q+kZ5/4uh+epdFlaeQk1bewxjJjVFLNYGYJV6u+wb8wHLjIdykYIiRWrgvy45GK0iOGVD7aCHVc1rlLTrrrUF8qFclPi1liqnTRhRs8fC87i+tjteCSlOH1hijdkyFyEg9QY7wedQ8cnz1hAa47MLpDBH/418seOjYm2NJ6HQSu4PA1uggd3OXMRp2nAMvxGwnTWFZ1yoauZeUKwlu8UoOOwzzJK+9RcjhcN1cTo8vjq73jW0y9aJKSnmT2lQ8HtR0rKJovkgOkHS3uM25OTTxX5owx32w8N+rZnjaCIiOqrPRr95v2BW/0FTgjZjAklwz9vycjH4d/GeKW0HOthccqLQsFoUUFOpwrRcXElWOnzRm+4N+XmbSZe+XtQ23W7ywh6uER+nWl9/24Fc0bPSNaraju7EJR9Ro8E0QPcq2M9vPOECihAVI8T12a4T92OpPk0F7jq749ITIEWqxZdHiJGwkkKI86TNGag5tlT23B6YRyCMUNeShBT0hYUkOrxTTxXrMI+gtNfWTKTxc7oUDATM/E4qE8MgqFOkaCc+oEPXaheSjXKes+31+pe9Hda3u2ORvx5vM9Ds0CMd7cCl1QsyeORBAgheisWLkPtGdowkL2KsX42BH7sCb4a6x/RtJHAY581BcUJrbeBq7o7I+YVpIcQtP004H06AqLmCedddfHcySVl5FAUtxLRszgJJjuL9hxLZvKPTjL3db5PuFJYG+oI0t9IqBBd3AtCX00xiqtWEajQE548rm5MLFR9dwGAEjRGmyBVnOZDBId1TiLyymuqCrilcYJ3bz7xGR8HGgxVrRiT44NNGIprOkQv9kb3Fy8ZllXFMa8h7rFC3qVg2M3p6mVCOMGNVBML5kyXyLQ7CNbgQDVc9ep49XcP+Ij2uKORHUZ3SfDJZd57oR0NNwA5nzNOLOc+wlwYAaRSOHKIKh9UM5RdqZy5lU2kNWOwfovvoReYNWm6P80s3/r8PQ/n3MutbsEGJ2mWBSslGdo+JH6pYd2hg/rlISngXndT0GwzocFRcmjddpXY67OV0sUaTepGzWr3ntujW0/IJRC1Zej0SXDaiR+e9VyE7rgTuoU2gEiU0N5Lqbr5tZuqx8TGXs3cQLyZpC6wH+LdyTF4J0fmDlIBphe7r5IDCRBG8eOXuZRXGSoGPYaOmA2PUJefh7fVflc0LG36i5MQmF/KI7fTxavg+8/kH4gIh3S40X5V0sPxsNKPfNKJwKE2RPVXIqHzzWyPqEqwAI8PZZb1RrnI9nzlDH5UF3tIH4Cibmn0iifDFXW96ZT5fE57MAXFk90gfVIGCfg4AuR4aM5j0gr/LCPd3N6BDUGN1NelVsHfjf3J+sdlBhSHN31bcMDLqLXz8dGrKRAK/MWOhF2OhmanABLLp6+pDkzNItsgH08ZyyictMPUQuHIG+bBQlF53b0fbgQIZ5Q4O72zfCMDEz55qAIvc0NBuJIZumsUxUe7Dk0LLqjzZdfMivzdNmBJpATZOf72RZOHaUHehpecqOLXIk83Vsn0u77qIiJDsIXz45stg1ApnELGWM0VEJvaK1cD2WSJ2n8U/Phe9ynHcCNTjeSblB41b5icDZw0TNmU3QKtNovfZ8UUwgMNsbgxh+UCxhDYwfn3tfMk+iRRHn9pCougsMx/+0ungeJkxnZD5Z1Ux9G1vuTO6b0AeFnuNUoLpuo2K+Zu9RkI1rBfFFosSzJkk/G3REuZHMPQ5/WghwR0T848P3BbNsEJQWXao/PdtGXVN1OTuauMJVZFwSX98ndPmSQIbnB/ATIeKecx0+HLq7uxCzEFkmD3Cc+g4+jYg9YwBCyveCxRcOeDh5Xk5S18jBMbM2oDvLR9pKgEo1kaG4FJeH9vIVQbniQcqemdr86ZG8MzXlyZjfU8+rFrYToSRpCxV217GlWcf1tJEicM9IoMr2OxW254PlBgMfrHJc89wfmzHhs5+Bs82zEl8OiwGTh0GgxCDrhZ/z6RRywPG2aG4BcsGo6RGrp0ggzt8UtJSfvtpWcIq8iiKVcwTRzBW/UB534GohOljBPEQ+3z5sR7CpyW/aUCTbLtvBgg32osefXBOh9+KVhJI4dSM5OqIie2ohUk1l9wFEE3csezdgrydGTzeejGTbARd0Vlg8+5aa8Pjp52qR3SAtKrMYhV4pnRVKQNj5Q+cG9SCQ9mgSEjSHIVn7QAEFsnqvuMcEbfq/kcuT/zW7TLvJ4ttp8VsABhQBIss2uO2Sr8uzBnfcVGSvQJOux2uKF+tESgB9uFNQ6dNnr4UXGAa/FVoA+BWavJEsUOtafDzsuvypNyhqsN2xdaGxSYF8W/oI9AWcfrT8uxEoKGRWG+A8OkI2e0eq5RAudLh6rrlLh780d8TxP58UhGod6pOBKroGpmVj3ST9geZ67UfueS+bLv/Pu5Fhpv2/F4F3ZSzgJxIFnMZhuqmzEpCo0ezxMEQfO0TQuvQijElCxc9l0dJz1hAqslxGSKpjS7JnoGha7MHEvczLnl0d4hu+6gN2eIC8nGKS0oV8u5x/oZP6QpriEmZfPI9am/mQ2%iB",
         "storeUrl": "https://www.xbox.com/games/store/skul-the-hero-slayer/9NW4Z3HPJVKW"
     },
@@ -5006,11 +5020,11 @@
         "releaseDate": "13/08/2019",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/slay-the-spire/9P6W46XMDJM5",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.17795.14612220527269160.ea029917-6726-4b37-a510-8449863efad4.b02e1597-5ccb-4d20-84de-4c53b702bcbb?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.17795.14612220527269160.ea029917-6726-4b37-a510-8449863efad4.b02e1597-5ccb-4d20-84de-4c53b702bcbb?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.23915.14612220527269160.ea029917-6726-4b37-a510-8449863efad4.26be57ed-6cf3-48da-9c65-eb533fed3b76?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/slay-the-spire/9P6W46XMDJM5"
     },
@@ -5025,32 +5039,13 @@
         "releaseDate": "22/09/2022",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/slime-rancher-2/9PHFJ0N31NV1",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.65089.14232893733292770.c4910fc1-e043-4370-be7c-79114ae9c0cf.d736574b-a3ed-4925-a26b-c05b56e621a5?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.65089.14232893733292770.c4910fc1-e043-4370-be7c-79114ae9c0cf.d736574b-a3ed-4925-a26b-c05b56e621a5?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.56117.14232893733292770.c4910fc1-e043-4370-be7c-79114ae9c0cf.22788af6-315d-4873-a561-751d3b6e3fe7?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/slime-rancher-2/9PHFJ0N31NV1"
-    },
-    {
-        "gameTitle": "Sniper Elite 4",
-        "gamePublisher": "Rebellion Developments Ltd",
-        "gameDeveloper": "Rebellion Developments Ltd",
-        "gameGenres": [
-            "A\u00e7\u00e3o e aventura",
-            "Jogos de tiros"
-        ],
-        "releaseDate": "13/02/2017",
-        "extraGameProperties": {
-            "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
-        },
-        "xcloudUrl": "https://www.xbox.com/%s/play/games/sniper-elite-4/BZ5VLVX84STW",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.26770.64044195348567726.135f2cd2-9709-4fe7-a7ca-fefaee870959.3982bd5f-c6ad-4116-a2c1-43c1b0b3baa5?w=%i&h=%i",
-        "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.10484.64044195348567726.135f2cd2-9709-4fe7-a7ca-fefaee870959.df995160-2b2a-4933-bbce-7409fff225e0?h=%i&format=jpg",
-        "storeUrl": "https://www.xbox.com/games/store/sniper-elite-4/BZ5VLVX84STW"
     },
     {
         "gameTitle": "Sniper Elite 5",
@@ -5063,11 +5058,11 @@
         "releaseDate": "25/05/2022",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/sniper-elite-5/9PP8Q82H79LC",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.28227.14329012547000484.584f0993-bf4d-4047-854d-bac80c1f8bf8.e7de3480-7471-4d8b-8745-bd02162add7b?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.28227.14329012547000484.584f0993-bf4d-4047-854d-bac80c1f8bf8.e7de3480-7471-4d8b-8745-bd02162add7b?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.21966.14329012547000484.7cb39222-264a-4c98-a0f1-007c4e95f1e1.664b113d-5f5a-43fe-9c1e-a1fa8a1915c1?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/sniper-elite-5/9PP8Q82H79LC"
     },
@@ -5081,13 +5076,32 @@
         "releaseDate": "17/05/2021",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/snowrunner/9PNRSC0J6DT8",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.55989.13956056585254053.d21b86eb-3deb-434c-9c26-3ab2103cddee.de74032c-1317-49a7-8fbb-1e6cd211985c?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.55989.13956056585254053.d21b86eb-3deb-434c-9c26-3ab2103cddee.de74032c-1317-49a7-8fbb-1e6cd211985c?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.29935.13956056585254053.d21b86eb-3deb-434c-9c26-3ab2103cddee.610128c5-2a44-4875-9cfb-9a110aa2a82e?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/snowrunner/9PNRSC0J6DT8"
+    },
+    {
+        "gameTitle": "Soccer Story",
+        "gamePublisher": "No More Robots",
+        "gameDeveloper": "PanicBarn",
+        "gameGenres": [
+            "A\u00e7\u00e3o e aventura",
+            "Fam\u00edlia e crian\u00e7as"
+        ],
+        "releaseDate": "28/11/2022",
+        "extraGameProperties": {
+            "isInGamePass": true,
+            "controllerSupport": true,
+            "touchControllerSupport": false
+        },
+        "xcloudUrl": "https://www.xbox.com/%s/play/games/soccer-story/9PJ1045MHZJ0",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.16567.14225521066737419.4d59d91e-770c-4a84-9fda-21fa57c19bbc.a99bcfc5-804f-4e1f-8e14-e27ad70afbc4?w=%i&format=jpg",
+        "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.54220.14225521066737419.4d59d91e-770c-4a84-9fda-21fa57c19bbc.af62fb1e-8600-4163-b871-03b245cf84a8?h=%i&format=jpg",
+        "storeUrl": "https://www.xbox.com/games/store/soccer-story/9PJ1045MHZJ0"
     },
     {
         "gameTitle": "Solasta: Crown of the Magister",
@@ -5100,32 +5114,32 @@
         "releaseDate": "27/05/2021",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/solasta-crown-of-the-magister/9N1KQPLTR7S5",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.60384.13899562469464238.c1646c67-46ab-4599-8b51-491c5f064ca0.100258cb-4e28-4a7a-b0a4-66a3e0a1bd0f?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.60384.13899562469464238.c1646c67-46ab-4599-8b51-491c5f064ca0.100258cb-4e28-4a7a-b0a4-66a3e0a1bd0f?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.27285.13899562469464238.e8d39ba5-ed7e-40a7-825b-f26621c5b4b7.d5c40d8a-6137-47c6-9eef-d26a584c5ec0?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/solasta-crown-of-the-magister/9N1KQPLTR7S5"
     },
     {
-        "gameTitle": "Space Warlord Organ Trading Simulator",
-        "gamePublisher": "Strange Scaffold",
-        "gameDeveloper": "Strange Scaffold",
+        "gameTitle": "Somerville",
+        "gamePublisher": "Jumpship",
+        "gameDeveloper": "Jumpship",
         "gameGenres": [
-            "Simula\u00e7\u00e3o",
-            "Estrat\u00e9gia"
+            "A\u00e7\u00e3o e aventura",
+            "Plataforma"
         ],
-        "releaseDate": "07/12/2021",
+        "releaseDate": "14/11/2022",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
-        "xcloudUrl": "https://www.xbox.com/%s/play/games/space-warlord-organ-trading-simulator/9NVD5DB5T3HD",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.2769.14396653708129733.be3550ae-ecb9-49ec-9472-c70a3c588ca1.553ca869-878d-46a5-8efe-10b83d9aa248?w=%i&h=%i",
-        "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.9974.14396653708129733.be3550ae-ecb9-49ec-9472-c70a3c588ca1.65d21e51-1238-427e-9438-97aecb73bb01?h=%i&format=jpg",
-        "storeUrl": "https://www.xbox.com/games/store/space-warlord-organ-trading-simulator/9NVD5DB5T3HD"
+        "xcloudUrl": "https://www.xbox.com/%s/play/games/somerville/9N1PS56BR6VK",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.51382.13901545943501690.6f65c9ca-e6b9-46e0-bfef-3d4b7f211abf.087d7caa-7f19-43de-8558-dd8c3c559a27?w=%i&format=jpg",
+        "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.25096.13901545943501690.6f65c9ca-e6b9-46e0-bfef-3d4b7f211abf.d74f5b96-6b79-4a48-bb34-cf5cc44a6c5d?h=%i&format=jpg",
+        "storeUrl": "https://www.xbox.com/games/store/somerville/9N1PS56BR6VK"
     },
     {
         "gameTitle": "Spacelines from the Far Out",
@@ -5138,11 +5152,11 @@
         "releaseDate": "06/06/2022",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/spacelines-from-the-far-out/9N23WV1HGLTQ",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.38917.13959665698666699.3d366e8c-44dc-4996-8b18-05749431b95e.4f5f537e-197a-41cd-a071-f956879553aa?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.38917.13959665698666699.3d366e8c-44dc-4996-8b18-05749431b95e.4f5f537e-197a-41cd-a071-f956879553aa?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.33739.13959665698666699.3d366e8c-44dc-4996-8b18-05749431b95e.31f79e40-e0e6-43ce-886f-5355fd5aa589?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/spacelines-from-the-far-out/9N23WV1HGLTQ"
     },
@@ -5157,11 +5171,11 @@
         "releaseDate": "12/01/2022",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/spelunky-2/9PM85QK6C13H",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.27081.14298096177274930.caec21fb-7c68-4a6c-b169-f9b7429b0fcd.d5428b70-a412-41ed-9a2c-0b36ac91c370?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.27081.14298096177274930.caec21fb-7c68-4a6c-b169-f9b7429b0fcd.d5428b70-a412-41ed-9a2c-0b36ac91c370?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.10415.14298096177274930.caec21fb-7c68-4a6c-b169-f9b7429b0fcd.9946e755-ccd7-4438-af6f-0e63da99c4a2?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/spelunky-2/9PM85QK6C13H"
     },
@@ -5176,11 +5190,11 @@
         "releaseDate": "22/09/2022",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/spiderheck/9N0TRF57SMQH",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.49869.13918689285493336.0819ed4c-c94e-42c7-bd95-af9916211f52.ee71f670-1904-4520-89fe-e3946aa7f270?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.49869.13918689285493336.0819ed4c-c94e-42c7-bd95-af9916211f52.ee71f670-1904-4520-89fe-e3946aa7f270?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.57425.13918689285493336.0819ed4c-c94e-42c7-bd95-af9916211f52.e581e622-2309-4e27-aae4-65e17506a0d1?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/spiderheck/9N0TRF57SMQH"
     },
@@ -5195,11 +5209,11 @@
         "releaseDate": "13/12/2016",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/stardew-valley/C3D891Z6TNQM",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.49352.65985311967005000.4f51b5e9-febf-4990-8951-33ba59b634c9.aace9b9e-b001-46eb-a39b-08b1332810aa?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.49352.65985311967005000.4f51b5e9-febf-4990-8951-33ba59b634c9.aace9b9e-b001-46eb-a39b-08b1332810aa?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.46577.65985311967005000.4f51b5e9-febf-4990-8951-33ba59b634c9.53fbd86d-c51b-4aa2-86e8-b4f5a8b4e7b2?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/stardew-valley/C3D891Z6TNQM"
     },
@@ -5214,11 +5228,11 @@
         "releaseDate": "22/05/2018",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/state-of-decay-2-juggernaut-edition/9NT4X7P8B9NB",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.62160.14425140369408817.14846606-f5bc-4fb1-b355-26ef6a25e847.e14fc031-2974-4b66-9f84-16cf8d0807e9?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.62160.14425140369408817.14846606-f5bc-4fb1-b355-26ef6a25e847.e14fc031-2974-4b66-9f84-16cf8d0807e9?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.48341.14425140369408817.5de04141-75f8-479c-a81d-b275bdb252fc.b570e967-e2fc-48be-87dd-0b19425ffe0b?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/state-of-decay-2-juggernaut-edition/9NT4X7P8B9NB"
     },
@@ -5233,32 +5247,13 @@
         "releaseDate": "25/02/2019",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/stellaris-console-edition/BWL72GR7Z7GK",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.10542.71592693192229022.95f29c62-8ab9-4865-a362-219a5bf8c0d3.e1fbe4bc-1592-40a9-8545-1d76aef61a11?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.10542.71592693192229022.95f29c62-8ab9-4865-a362-219a5bf8c0d3.e1fbe4bc-1592-40a9-8545-1d76aef61a11?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.33281.71592693192229022.95f29c62-8ab9-4865-a362-219a5bf8c0d3.6375b03f-0de8-43df-aa96-a92013c301b3?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/stellaris-console-edition/BWL72GR7Z7GK"
-    },
-    {
-        "gameTitle": "Subnautica",
-        "gamePublisher": "Unknown Worlds Entertainment",
-        "gameDeveloper": "Unknown Worlds, Grip Games, and Panic Button",
-        "gameGenres": [
-            "A\u00e7\u00e3o e aventura",
-            "Outros"
-        ],
-        "releaseDate": "03/12/2018",
-        "extraGameProperties": {
-            "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
-        },
-        "xcloudUrl": "https://www.xbox.com/%s/play/games/subnautica/BX3S1Q5DVHRD",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.19794.63409341877910445.4fd452e1-c3ee-4448-a0f8-ac6eb6bdaabf.8fe60020-9cc9-42c9-af2a-bf7b08cb5e13?w=%i&h=%i",
-        "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.23135.63409341877910445.4fd452e1-c3ee-4448-a0f8-ac6eb6bdaabf.5a02df2f-4cea-4002-856b-2f4f478da7e9?h=%i&format=jpg",
-        "storeUrl": "https://www.xbox.com/games/store/subnautica/BX3S1Q5DVHRD"
     },
     {
         "gameTitle": "Super Mega Baseball 3",
@@ -5271,11 +5266,11 @@
         "releaseDate": "13/05/2020",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/super-mega-baseball-3/9NP6V9LFVJ87",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.12287.13728510900587088.c32ad4cb-c837-4a7f-ab8d-c3d9ca2cb384.15cf7c9c-94b9-441e-99f5-b58eb5e57040?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.12287.13728510900587088.c32ad4cb-c837-4a7f-ab8d-c3d9ca2cb384.15cf7c9c-94b9-441e-99f5-b58eb5e57040?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.16577.13728510900587088.c32ad4cb-c837-4a7f-ab8d-c3d9ca2cb384.c71fc5d0-f4f7-40d4-b971-7b61004c57ed?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/super-mega-baseball-3/9NP6V9LFVJ87"
     },
@@ -5290,32 +5285,13 @@
         "releaseDate": "07/07/2020",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/superliminal/9NVR4ZQKNBSB",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.47663.14393569011623061.24d2b16b-20df-48f4-b265-623d2c0e948a.37ffa286-743f-4c55-9e7d-7c93def066a0?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.47663.14393569011623061.24d2b16b-20df-48f4-b265-623d2c0e948a.37ffa286-743f-4c55-9e7d-7c93def066a0?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.1690.14393569011623061.24d2b16b-20df-48f4-b265-623d2c0e948a.b161efbf-815b-4aee-9d82-f815731bd218?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/superliminal/9NVR4ZQKNBSB"
-    },
-    {
-        "gameTitle": "Supraland",
-        "gamePublisher": "Humble Games",
-        "gameDeveloper": "Supra Games",
-        "gameGenres": [
-            "A\u00e7\u00e3o e aventura",
-            "Plataforma"
-        ],
-        "releaseDate": "21/10/2020",
-        "extraGameProperties": {
-            "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
-        },
-        "xcloudUrl": "https://www.xbox.com/%s/play/games/supraland/9PN6MTJX8LZD",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.32154.14354148193968541.017a6808-d170-40f2-a4c6-5b8716a41d7c.39a5082b-f046-4ab8-aba0-6b27aad146e2?w=%i&h=%i",
-        "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.65473.14354148193968541.017a6808-d170-40f2-a4c6-5b8716a41d7c.2d7a9260-047c-4444-8e71-6529e3e57aef?h=%i&format=jpg",
-        "storeUrl": "https://www.xbox.com/games/store/supraland/9PN6MTJX8LZD"
     },
     {
         "gameTitle": "Surgeon Simulator 2",
@@ -5328,32 +5304,13 @@
         "releaseDate": "02/09/2021",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/surgeon-simulator-2/9NPPK20VCTGM",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.34455.13784877875223300.82d0e530-8878-4d4f-a9e5-9c3529471840.113556c3-95a3-4c60-9063-d5a6f47cf797?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.34455.13784877875223300.82d0e530-8878-4d4f-a9e5-9c3529471840.113556c3-95a3-4c60-9063-d5a6f47cf797?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.17837.13784877875223300.82d0e530-8878-4d4f-a9e5-9c3529471840.bdce890c-f2b2-4983-ad2b-907ddd80cf0b?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/surgeon-simulator-2/9NPPK20VCTGM"
-    },
-    {
-        "gameTitle": "TRANSFORMERS: CAMPOS DE BATALHA",
-        "gamePublisher": "Outright Games Ltd",
-        "gameDeveloper": "Coatsink",
-        "gameGenres": [
-            "Fam\u00edlia e crian\u00e7as",
-            "Estrat\u00e9gia"
-        ],
-        "releaseDate": "22/10/2020",
-        "extraGameProperties": {
-            "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
-        },
-        "xcloudUrl": "https://www.xbox.com/%s/play/games/transformers-battlegrounds/9PCQRLT7C2BH",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.28464.14168906857029084.1dec8aac-a444-4171-afe3-510e35a0dfa3.4307eb30-534c-4cec-908f-9b70dd88b95a?w=%i&h=%i",
-        "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.20008.14168906857029084.1dec8aac-a444-4171-afe3-510e35a0dfa3.99868f35-7235-4200-9b68-f505f20283a3?h=%i&format=jpg",
-        "storeUrl": "https://www.xbox.com/games/store/transformers-campos-de-batalha/9PCQRLT7C2BH"
     },
     {
         "gameTitle": "TUNIC",
@@ -5365,11 +5322,11 @@
         "releaseDate": "16/03/2022",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/tunic/9NLRT31Z4RWM",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.5223.13702044937897358.8701ab78-da18-4c36-8c1e-3d4e6dfd60c9.31c8ed6f-acf1-4cf2-9863-640fe319abc3?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.5223.13702044937897358.8701ab78-da18-4c36-8c1e-3d4e6dfd60c9.31c8ed6f-acf1-4cf2-9863-640fe319abc3?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.34105.13702044937897358.8701ab78-da18-4c36-8c1e-3d4e6dfd60c9.86f47a6b-716e-40fa-aa62-61bf6f6e102c?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/tunic/9NLRT31Z4RWM"
     },
@@ -5384,11 +5341,11 @@
         "releaseDate": "22/09/2021",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/tainted-grail-conquest/9MZGGWHPKQ4C",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.20262.13875132150834532.ace67c6c-ec94-4b40-8c63-1fe7e6049203.ed00104f-535d-4b8a-9052-2dcaa3e702ba?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.20262.13875132150834532.ace67c6c-ec94-4b40-8c63-1fe7e6049203.ed00104f-535d-4b8a-9052-2dcaa3e702ba?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.39372.13875132150834532.ace67c6c-ec94-4b40-8c63-1fe7e6049203.ced1c496-e9e9-4389-bd6e-fbc0df5a734e?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/tainted-grail-conquest/9MZGGWHPKQ4C"
     },
@@ -5402,11 +5359,11 @@
         "releaseDate": "16/06/2022",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/teenage-mutant-ninja-turtles-shredder's-revenge/9NS3673HVH41",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.59000.14375592271313618.c7999e35-c8d7-49d4-b3fa-e5e1009423d7.a816f588-b6ba-46c0-8f39-54ca543455cf?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.59000.14375592271313618.c7999e35-c8d7-49d4-b3fa-e5e1009423d7.a816f588-b6ba-46c0-8f39-54ca543455cf?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.12667.14375592271313618.8101bdfc-97e9-473f-8ca0-07fc83b1846b.84baa4ab-83cb-4dfa-b83c-baa8e9ee8bba?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/teenage-mutant-ninja-turtles-shredder's-revenge/9NS3673HVH41"
     },
@@ -5420,11 +5377,11 @@
         "releaseDate": "27/08/2020",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/tell-me-why-chapters-1-3/9NF83PRZK6K3",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.56500.13599353568798630.567fc0f9-a81e-456c-a9ee-55bb0bb153b5.a110b76d-abae-4dd7-a578-a796ea66ff53?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.56500.13599353568798630.567fc0f9-a81e-456c-a9ee-55bb0bb153b5.a110b76d-abae-4dd7-a578-a796ea66ff53?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.767.13599353568798630.567fc0f9-a81e-456c-a9ee-55bb0bb153b5.9160630f-b7b8-470d-a39f-8d36788ec893?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/tell-me-why-cap%C3%ADtulo-1-3/9NF83PRZK6K3"
     },
@@ -5438,11 +5395,11 @@
         "releaseDate": "28/04/2020",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/telling-lies/9NLHWTCWLKGX",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.9486.13711287244755811.601b477c-0175-48da-8585-ae8d926ee15d.6d1bc680-0946-4ac2-a288-84ab77630eed?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.9486.13711287244755811.601b477c-0175-48da-8585-ae8d926ee15d.6d1bc680-0946-4ac2-a288-84ab77630eed?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.53430.13711287244755811.601b477c-0175-48da-8585-ae8d926ee15d.b6c23b53-a203-4b86-a4ce-897bad0b5e35?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/telling-lies/9NLHWTCWLKGX"
     },
@@ -5457,11 +5414,11 @@
         "releaseDate": "13/11/2014",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/terraria/BTNPS60N3114",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.57835.70406876433810089.4beffaca-3fee-4154-a21f-ecd9b3bedbb3.c2203645-e73c-4760-bdbe-f1bcf32a0a05?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.57835.70406876433810089.4beffaca-3fee-4154-a21f-ecd9b3bedbb3.c2203645-e73c-4760-bdbe-f1bcf32a0a05?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.15385.70406876433810089.4beffaca-3fee-4154-a21f-ecd9b3bedbb3.14eef101-5fe5-4892-bc4f-c290d9d50d7c?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/terraria/BTNPS60N3114"
     },
@@ -5476,11 +5433,11 @@
         "releaseDate": "31/12/2799",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/the-anacrusis-game-preview/9P9S593SLMV7",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.51812.14132627781219400.b75eb479-8d85-476a-9b12-d9044cad7c6e.6e935896-30f8-4e35-8a8c-c807747adc55?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.51812.14132627781219400.b75eb479-8d85-476a-9b12-d9044cad7c6e.6e935896-30f8-4e35-8a8c-c807747adc55?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.51176.14132627781219400.e2eafad1-9336-41a2-a8bc-d64f901c1136.89ce799a-9fb2-46ae-afb2-1647846e6252?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/the-anacrusis-pr%C3%A9via-do-jogo/9P9S593SLMV7"
     },
@@ -5495,11 +5452,11 @@
         "releaseDate": "29/07/2021",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/the-ascent/C27QL5JBKQ8M",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.31847.65332188737297236.e956bc32-e423-4920-b547-86181e7ed68d.75126036-bcfe-471a-80ff-394c854dd7d2?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.31847.65332188737297236.e956bc32-e423-4920-b547-86181e7ed68d.75126036-bcfe-471a-80ff-394c854dd7d2?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.36256.65332188737297236.e956bc32-e423-4920-b547-86181e7ed68d.eaa95a80-a4c4-4c13-92c8-ff26e9da1314?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/the-ascent/C27QL5JBKQ8M"
     },
@@ -5514,11 +5471,11 @@
         "releaseDate": "18/06/2020",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/the-bard's-tale-arpg-remastered-and-resnarkled/9PN3VDFTB5HZ",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.44758.14351919773829236.17768c0e-ff0d-4fe7-86a5-a0cdd0bfe3a6.697c7bb1-b26f-4759-a90b-d2dbac5e5b2e?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.44758.14351919773829236.17768c0e-ff0d-4fe7-86a5-a0cdd0bfe3a6.697c7bb1-b26f-4759-a90b-d2dbac5e5b2e?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.18671.14351919773829236.17768c0e-ff0d-4fe7-86a5-a0cdd0bfe3a6.42dffd5c-f70e-4af8-9323-7c725c28badb?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/the-bard's-tale-arpg-remastered-and-resnarkled/9PN3VDFTB5HZ"
     },
@@ -5533,11 +5490,11 @@
         "releaseDate": "27/08/2019",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/the-bard's-tale-iv-director's-cut/C2B4T86TXLRS",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.34604.65351109767529701.defb4d0d-acab-4fd9-8208-7283068f991e.34d0241a-bbac-43d8-8e46-541283f89936?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.34604.65351109767529701.defb4d0d-acab-4fd9-8208-7283068f991e.34d0241a-bbac-43d8-8e46-541283f89936?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.59914.65351109767529701.defb4d0d-acab-4fd9-8208-7283068f991e.b1a96c89-6ec6-4529-bce6-847b80bce632?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/the-bard's-tale-iv-director's-cut/C2B4T86TXLRS"
     },
@@ -5552,11 +5509,11 @@
         "releaseDate": "13/08/2019",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/the-bard's-tale-trilogy/9MVN4ND41DD3",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.58193.13855942306543540.f07392fd-5f64-460d-82f5-27790455d1e0.be4aa1b8-dc12-4784-9111-96d6c245d360?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.58193.13855942306543540.f07392fd-5f64-460d-82f5-27790455d1e0.be4aa1b8-dc12-4784-9111-96d6c245d360?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.59104.13855942306543540.f07392fd-5f64-460d-82f5-27790455d1e0.3501f74c-cb28-4bc9-bbf5-04ed2c308e5d?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/the-bard's-tale-trilogy/9MVN4ND41DD3"
     },
@@ -5571,11 +5528,11 @@
         "releaseDate": "23/06/2021",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/the-dungeon-of-naheulbeuk-the-amulet-of-chaos---ch/9MT8HTJC4GSB",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.45055.13817077164703749.cd543429-7cae-4721-ab65-6ad0bd406b04.59c45932-b890-4f8a-8e25-c99672f1df24?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.45055.13817077164703749.cd543429-7cae-4721-ab65-6ad0bd406b04.59c45932-b890-4f8a-8e25-c99672f1df24?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.64340.13817077164703749.cd543429-7cae-4721-ab65-6ad0bd406b04.1c008e07-0a79-4062-843b-9d1f0ee2e6c7?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/the-dungeon-of-naheulbeuk-the-amulet-of-chaos---ch/9MT8HTJC4GSB"
     },
@@ -5589,11 +5546,11 @@
         "releaseDate": "16/04/2018",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/the-elder-scrolls-iii-morrowind/BXVCFBJBNS17",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.23519.63316511565903586.d62160f8-6032-426e-af13-d87fe2d204a7.22bb08a7-a717-490d-8d63-036a3db4dc92?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.23519.63316511565903586.d62160f8-6032-426e-af13-d87fe2d204a7.22bb08a7-a717-490d-8d63-036a3db4dc92?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.44690.63316511565903586.d62160f8-6032-426e-af13-d87fe2d204a7.eea1eec7-7361-48c9-bbce-ac54d9d26b50?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/the-elder-scrolls-iii-morrowind/BXVCFBJBNS17"
     },
@@ -5607,13 +5564,31 @@
         "releaseDate": "27/10/2016",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/the-elder-scrolls-v-skyrim-special-edition/BQ1W1T1FC14W",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.4794.68326442227858632.03782b23-7f26-4a8e-ba87-177bdf2c3c90.b156af1e-9796-48af-8d11-3461727280ea?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.4794.68326442227858632.03782b23-7f26-4a8e-ba87-177bdf2c3c90.b156af1e-9796-48af-8d11-3461727280ea?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.62159.68326442227858632.03782b23-7f26-4a8e-ba87-177bdf2c3c90.1405eb3a-6314-4e44-a822-7660d70a6ec5?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/the-elder-scrolls-v-skyrim-special-edition/BQ1W1T1FC14W"
+    },
+    {
+        "gameTitle": "The Elder Scrolls\u00ae Online",
+        "gamePublisher": "Bethesda Softworks",
+        "gameDeveloper": "ZeniMax Online Studios",
+        "gameGenres": [
+            "RPG"
+        ],
+        "releaseDate": "05/06/2017",
+        "extraGameProperties": {
+            "isInGamePass": true,
+            "controllerSupport": true,
+            "touchControllerSupport": false
+        },
+        "xcloudUrl": "https://www.xbox.com/%s/play/games/the-elder-scrolls-online/BRKX5CRMRTC2",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.5.69742768075920623.e6c8e1ee-e782-4002-bca6-916e5cd2f37c.c83904e1-a85d-4e2a-9d8c-63e0acacc011?w=%i&format=jpg",
+        "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.42994.69742768075920623.e6c8e1ee-e782-4002-bca6-916e5cd2f37c.72f4ca2d-e167-4637-aac3-c9c37eaec0b7?h=%i&format=jpg",
+        "storeUrl": "https://www.xbox.com/games/store/the-elder-scrolls-online/BRKX5CRMRTC2"
     },
     {
         "gameTitle": "The Evil Within",
@@ -5625,11 +5600,11 @@
         "releaseDate": "13/10/2014",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/the-evil-within/C2M8HBNVPT1T",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.49736.65523398993639028.2c280ccc-7f03-4d25-8060-07f62a42af2f.f6c60388-390b-428f-8206-af048885200c?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.49736.65523398993639028.2c280ccc-7f03-4d25-8060-07f62a42af2f.f6c60388-390b-428f-8206-af048885200c?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.21330.65523398993639028.2c280ccc-7f03-4d25-8060-07f62a42af2f.bb372e99-a65a-408c-a4c5-08c63fe35051?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/the-evil-within/C2M8HBNVPT1T"
     },
@@ -5643,32 +5618,13 @@
         "releaseDate": "12/10/2017",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/the-evil-within-2/C40860J5R2MP",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.54557.66902085872217864.df676289-5ef8-4c7c-8533-965928392024.79369858-479b-4542-991a-cfffd2af454b?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.54557.66902085872217864.df676289-5ef8-4c7c-8533-965928392024.79369858-479b-4542-991a-cfffd2af454b?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.10235.66902085872217864.df676289-5ef8-4c7c-8533-965928392024.db6ff62f-dadd-41bf-916b-5738e03b9b63?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/the-evil-within-2/C40860J5R2MP"
-    },
-    {
-        "gameTitle": "The Forgotten City",
-        "gamePublisher": "Dear Villagers",
-        "gameDeveloper": "Modern Storyteller",
-        "gameGenres": [
-            "A\u00e7\u00e3o e aventura",
-            "RPG"
-        ],
-        "releaseDate": "28/07/2021",
-        "extraGameProperties": {
-            "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
-        },
-        "xcloudUrl": "https://www.xbox.com/%s/play/games/the-forgotten-city/9NJ4R763M7TH",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.53062.13683273960215638.5923ef51-2df1-4d4f-9d97-d8e9f37aa547.b48a871c-2640-4e5b-affe-490618dd2db1?w=%i&h=%i",
-        "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.54681.13683273960215638.5923ef51-2df1-4d4f-9d97-d8e9f37aa547.cff96ae2-adec-4b67-8ec6-89f368af6abf?h=%i&format=jpg",
-        "storeUrl": "https://www.xbox.com/games/store/the-forgotten-city/9NJ4R763M7TH"
     },
     {
         "gameTitle": "The Gunk",
@@ -5681,11 +5637,11 @@
         "releaseDate": "16/12/2021",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/the-gunk/9P008L2LS87F",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.1452.14466083566107896.f1b98327-0240-4097-b759-cc5bd89ee66e.5da87010-64a5-4dfb-9396-5e88d1630886?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.1452.14466083566107896.f1b98327-0240-4097-b759-cc5bd89ee66e.5da87010-64a5-4dfb-9396-5e88d1630886?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.58106.14466083566107896.f1b98327-0240-4097-b759-cc5bd89ee66e.5fab2823-b931-4d24-bf6d-46d16533da2e?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/the-gunk/9P008L2LS87F"
     },
@@ -5700,13 +5656,32 @@
         "releaseDate": "04/06/2021",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/the-last-kids-on-earth-and-the-staff-of-doom/9NQTJK43NCQJ",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.20735.13762649903394503.ccafcc44-7c4b-4fc6-9462-a3fcec235b79.34e55ab3-802e-4a09-9227-b44fc192e5b4?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.20735.13762649903394503.ccafcc44-7c4b-4fc6-9462-a3fcec235b79.34e55ab3-802e-4a09-9227-b44fc192e5b4?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.42017.13762649903394503.ab6e32ef-5ac4-49a8-8d5d-4893cabe8968.80520e05-0c7f-4e26-b1c9-f3b067712b04?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/the-last-kids-on-earth-and-the-staff-of-doom/9NQTJK43NCQJ"
+    },
+    {
+        "gameTitle": "The Legend of Tianding",
+        "gamePublisher": "Neon Doctrine",
+        "gameDeveloper": "Creative Games Computer Graphics Corporation and Neon Doctrine",
+        "gameGenres": [
+            "A\u00e7\u00e3o e aventura",
+            "Plataforma"
+        ],
+        "releaseDate": "31/10/2022",
+        "extraGameProperties": {
+            "isInGamePass": true,
+            "controllerSupport": true,
+            "touchControllerSupport": false
+        },
+        "xcloudUrl": "https://www.xbox.com/%s/play/games/the-legend-of-tianding/9NCBTKXHFF8K",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.29135.13571267565839258.64c6f711-671b-4bb1-8aea-935b6dc1ede0.0684f522-a7ac-4dda-ab1f-6d915a976967?w=%i&format=jpg",
+        "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.4979.13571267565839258.64c6f711-671b-4bb1-8aea-935b6dc1ede0.be3dcf69-1420-4846-9904-52f005327e1c?h=%i&format=jpg",
+        "storeUrl": "https://www.xbox.com/games/store/the-legend-of-tianding/9NCBTKXHFF8K"
     },
     {
         "gameTitle": "The Long Dark",
@@ -5719,11 +5694,11 @@
         "releaseDate": "31/07/2017",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/the-long-dark/C41ZDFQ82M1G",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.6991.66934420265726607.e7f79b00-768c-452b-bd03-0eb82296f498.5f5892b3-2241-4b20-835e-27ae0eaf7796?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.6991.66934420265726607.e7f79b00-768c-452b-bd03-0eb82296f498.5f5892b3-2241-4b20-835e-27ae0eaf7796?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.45412.66934420265726607.e7f79b00-768c-452b-bd03-0eb82296f498.96a38100-1f0c-4441-9a64-c6fb4289d989?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/the-long-dark/C41ZDFQ82M1G"
     },
@@ -5738,11 +5713,11 @@
         "releaseDate": "24/10/2019",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/the-outer-worlds/BVTKN6CQ8W5F",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.41558.71127714305215144.dfbe21c8-4e10-4861-b737-47393066d41d.a5829bf5-54b9-4e0f-b7a3-3772539dd491?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.41558.71127714305215144.dfbe21c8-4e10-4861-b737-47393066d41d.a5829bf5-54b9-4e0f-b7a3-3772539dd491?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.60817.71127714305215144.dfbe21c8-4e10-4861-b737-47393066d41d.cc6b6839-fb14-421b-814c-898b8e58a716?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/the-outer-worlds/BVTKN6CQ8W5F"
     },
@@ -5757,11 +5732,11 @@
         "releaseDate": "03/01/2022",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/the-pedestrian/9NTX07HR22TG",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.18714.14405641539368739.40cb973b-02de-48e6-af90-2792c037b42e.c3d93b01-fabd-4445-8d65-9c741af2fe80?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.18714.14405641539368739.40cb973b-02de-48e6-af90-2792c037b42e.c3d93b01-fabd-4445-8d65-9c741af2fe80?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.3542.14405641539368739.40cb973b-02de-48e6-af90-2792c037b42e.d535cfae-b8c0-405c-b347-ba0f40b3a182?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/the-pedestrian/9NTX07HR22TG"
     },
@@ -5776,13 +5751,31 @@
         "releaseDate": "13/10/2021",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/the-riftbreaker/9P94PCKP864B",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.14415.14074927307991469.b436fff7-157c-4e97-b957-11e9d6f0e0eb.4690e1cb-fa16-4030-abd9-583e75be3c9d?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.14415.14074927307991469.b436fff7-157c-4e97-b957-11e9d6f0e0eb.4690e1cb-fa16-4030-abd9-583e75be3c9d?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.28933.14074927307991469.b436fff7-157c-4e97-b957-11e9d6f0e0eb.76ec1461-a7c0-4a88-8dad-1884d00d1759?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/the-riftbreaker/9P94PCKP864B"
+    },
+    {
+        "gameTitle": "The Sims\u2122 4 Edi\u00e7\u00e3o EA Play",
+        "gamePublisher": "Electronic Arts",
+        "gameDeveloper": "Maxis & Blind Squirrel",
+        "gameGenres": [
+            "Simula\u00e7\u00e3o"
+        ],
+        "releaseDate": "29/12/9998",
+        "extraGameProperties": {
+            "isInGamePass": true,
+            "controllerSupport": true,
+            "touchControllerSupport": false
+        },
+        "xcloudUrl": "https://www.xbox.com/%s/play/games/the-sims-4-ea-play-edition/9PLFD17M47K3",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.29662.14318793375483754.bef3d00f-b454-4ca1-b55e-94fd2ae048e4.46331d6c-a378-4cc7-8684-b3ed472abb0d?w=%i&format=jpg",
+        "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.16747.14318793375483754.bef3d00f-b454-4ca1-b55e-94fd2ae048e4.e2eb74a7-7171-4496-9541-dc35c71e6981?h=%i&format=jpg",
+        "storeUrl": "https://www.xbox.com/games/store/the-sims-4-edi%C3%A7%C3%A3o-ea-play/9PLFD17M47K3"
     },
     {
         "gameTitle": "The Walking Dead: A New Frontier - The Complete Season (Episodes 1-5)",
@@ -5794,11 +5787,11 @@
         "releaseDate": "19/12/2016",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/the-walking-dead-a-new-frontier---the-complete-sea/BQR7QS0F8SJ3",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.25445.68746382496567220.612ba4aa-3f7b-4b25-b141-a20112197dde.672c59e8-ed5c-4277-b00b-62c66d6d6c51?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.25445.68746382496567220.612ba4aa-3f7b-4b25-b141-a20112197dde.672c59e8-ed5c-4277-b00b-62c66d6d6c51?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.51573.68746382496567220.612ba4aa-3f7b-4b25-b141-a20112197dde.0e3a2b14-f6c8-4538-972d-7b02e3c30134?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/the-walking-dead-a-new-frontier---the-complete-sea/BQR7QS0F8SJ3"
     },
@@ -5812,11 +5805,11 @@
         "releaseDate": "22/02/2016",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/the-walking-dead-michonne---the-complete-season/C2XNJC9WK15X",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.21725.66252839971129113.8f5f5ae5-f77d-4f3c-8388-3b220332b617.4c26174a-a955-4310-b9fc-fb9e561f7a9c?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.21725.66252839971129113.8f5f5ae5-f77d-4f3c-8388-3b220332b617.4c26174a-a955-4310-b9fc-fb9e561f7a9c?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.44390.66252839971129113.8f5f5ae5-f77d-4f3c-8388-3b220332b617.e2d2592d-3847-49a5-8158-a887da363ef6?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/the-walking-dead-michonne---the-complete-season/C2XNJC9WK15X"
     },
@@ -5830,11 +5823,11 @@
         "releaseDate": "20/10/2014",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/the-walking-dead-season-two/C2DQXX0CB42F",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.34948.65440315593285086.25acafbc-307e-448a-a7f5-999e7cc0c672.7c50a8dd-9a0b-4209-b5bf-a34ad0c24366?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.34948.65440315593285086.25acafbc-307e-448a-a7f5-999e7cc0c672.7c50a8dd-9a0b-4209-b5bf-a34ad0c24366?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.21436.65440315593285086.25acafbc-307e-448a-a7f5-999e7cc0c672.e5b18b09-7761-4c13-ab1a-b7a3ffcfa08c?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/the-walking-dead-season-two/C2DQXX0CB42F"
     },
@@ -5848,13 +5841,31 @@
         "releaseDate": "13/10/2014",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/the-walking-dead-the-complete-first-season/BW6B077FCH11",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.64194.71901737879009236.c4798d79-4139-4e57-bb07-d252b6ca567c.10c48ea9-4aa3-4672-b9f7-ac8087d4526f?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.64194.71901737879009236.c4798d79-4139-4e57-bb07-d252b6ca567c.10c48ea9-4aa3-4672-b9f7-ac8087d4526f?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.7774.71901737879009236.c4798d79-4139-4e57-bb07-d252b6ca567c.feb448b1-e5ea-4764-81f2-151d898e13ca?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/the-walking-dead-the-complete-first-season/BW6B077FCH11"
+    },
+    {
+        "gameTitle": "The Walking Dead: A Temporada Final - The Complete Season",
+        "gamePublisher": "Skybound Games",
+        "gameDeveloper": "Telltale Games",
+        "gameGenres": [
+            "A\u00e7\u00e3o e aventura"
+        ],
+        "releaseDate": "13/08/2018",
+        "extraGameProperties": {
+            "isInGamePass": true,
+            "controllerSupport": true,
+            "touchControllerSupport": false
+        },
+        "xcloudUrl": "https://www.xbox.com/%s/play/games/the-walking-dead-the-final-season---the-complete-s/C0VQBXFNZ1Q0",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.63360.65079731096933175.a08cf79d-9c48-4fcd-90eb-63df0c6a136c.4771e790-cd77-4316-a708-a82c7f28b996?w=%i&format=jpg",
+        "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.9967.65079731096933175.a08cf79d-9c48-4fcd-90eb-63df0c6a136c.694bcbcd-e366-4c1a-9ba1-96861c66d173?h=%i&format=jpg",
+        "storeUrl": "https://www.xbox.com/games/store/the-walking-dead-a-temporada-final---the-complete-/C0VQBXFNZ1Q0"
     },
     {
         "gameTitle": "This War of Mine: Final Cut",
@@ -5866,11 +5877,11 @@
         "releaseDate": "09/05/2022",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/this-war-of-mine-final-cut/9MT6TG9CXR2H",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.37303.13818178861591472.06d4cfd1-e581-4b7f-8268-7ed2cfca3f35.cd9123c5-f36e-4501-bf53-082666b3fa48?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.37303.13818178861591472.06d4cfd1-e581-4b7f-8268-7ed2cfca3f35.cd9123c5-f36e-4501-bf53-082666b3fa48?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.1709.13818178861591472.06d4cfd1-e581-4b7f-8268-7ed2cfca3f35.a8145a5b-1d4d-43f1-a537-9ebc0209a9c8?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/this-war-of-mine-final-cut/9MT6TG9CXR2H"
     },
@@ -5885,11 +5896,11 @@
         "releaseDate": "30/08/2022",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/tinykin/9NLLP82XVSKH",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.41283.13705408154411770.7cc771bf-fa30-454c-bfd5-e554674c2e74.79981d13-6d87-4215-8e1d-be83b443ed89?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.41283.13705408154411770.7cc771bf-fa30-454c-bfd5-e554674c2e74.79981d13-6d87-4215-8e1d-be83b443ed89?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.15256.13705408154411770.7cc771bf-fa30-454c-bfd5-e554674c2e74.ae4b9c15-0c98-4d2b-b049-b20992dc99f9?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/tinykin/9NLLP82XVSKH"
     },
@@ -5903,11 +5914,11 @@
         "releaseDate": "08/03/2022",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/tom-clancy's-rainbow-six-siege-deluxe-edition/9NSHNMCM0JR8",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.3515.14367438179754989.c0279dfe-426b-4a31-84c2-3cf57fd07773.462a3a44-858b-480a-90ef-7a3cbc9b28c2?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.3515.14367438179754989.c0279dfe-426b-4a31-84c2-3cf57fd07773.462a3a44-858b-480a-90ef-7a3cbc9b28c2?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.35709.14367438179754989.c0279dfe-426b-4a31-84c2-3cf57fd07773.3b0725c3-8d64-42b3-9245-58d5617ec956?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/tom-clancy's-rainbow-six-siege-deluxe-edition/9NSHNMCM0JR8"
     },
@@ -5921,11 +5932,11 @@
         "releaseDate": "06/03/2017",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/tom-clancy%E2%80%99s-ghost-recon-wildlands---standard-edit/C2N9CS4FS1QR",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.35914.65577870102127192.24a0a154-ded1-4a40-a91f-102019aaee70.04f5f3e1-2dd4-4cfb-b1e6-add402749f0a?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.35914.65577870102127192.24a0a154-ded1-4a40-a91f-102019aaee70.04f5f3e1-2dd4-4cfb-b1e6-add402749f0a?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.27896.65577870102127192.24a0a154-ded1-4a40-a91f-102019aaee70.a64b3aea-f6fc-4b1c-a933-7ee068590864?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/tom-clancy%E2%80%99s-ghost-recon-wildlands---standard-edit/C2N9CS4FS1QR"
     },
@@ -5940,11 +5951,11 @@
         "releaseDate": "19/01/2022",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/tom-clancy%E2%80%99s-rainbow-six-extraction/BXRB4ZH2GJHK",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.12410.63231504676176196.fce3b959-5f54-4aad-a199-00e19cf052ba.c309e2ab-1f04-4a32-8afc-381df080bb57?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.12410.63231504676176196.fce3b959-5f54-4aad-a199-00e19cf052ba.c309e2ab-1f04-4a32-8afc-381df080bb57?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.50084.63231504676176196.fce3b959-5f54-4aad-a199-00e19cf052ba.0fbf2fa3-423b-4ffc-8e42-a8e8360287b3?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/tom-clancy%E2%80%99s-rainbow-six-extraction/BXRB4ZH2GJHK"
     },
@@ -5959,11 +5970,11 @@
         "releaseDate": "27/02/2017",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/torment-tides-of-numenera/BQND4NQXFFV2",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.60839.69228847133651133.1a071f35-fd99-4884-ae4a-12f55849b9eb.8fd399bb-4620-497a-939c-722938a7b901?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.60839.69228847133651133.1a071f35-fd99-4884-ae4a-12f55849b9eb.8fd399bb-4620-497a-939c-722938a7b901?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.55786.69228847133651133.1a071f35-fd99-4884-ae4a-12f55849b9eb.02990022-0a33-4cef-996f-2254a0216e0e?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/torment-tides-of-numenera/BQND4NQXFFV2"
     },
@@ -5978,11 +5989,11 @@
         "releaseDate": "20/12/2019",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/totally-accurate-battle-simulator/9PC4RWP34M2D",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.25383.14176345306313891.79ca8837-5397-4838-85b6-4a8a9720856c.db23320a-e9f6-4ed3-87e5-db4a5e82a6fc?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.25383.14176345306313891.79ca8837-5397-4838-85b6-4a8a9720856c.db23320a-e9f6-4ed3-87e5-db4a5e82a6fc?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.8372.14176345306313891.79ca8837-5397-4838-85b6-4a8a9720856c.8d4e1080-09b7-4a26-aafa-58c34e4ebb7e?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/totally-accurate-battle-simulator/9PC4RWP34M2D"
     },
@@ -5997,11 +6008,11 @@
         "releaseDate": "31/03/2020",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/totally-reliable-delivery-service/9NZG72SH3H4W",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.57565.14481391283536320.2e278a9d-b63d-454a-a60e-ac81b25b445c.392440ba-2841-42da-9eae-3624c032300b?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.57565.14481391283536320.2e278a9d-b63d-454a-a60e-ac81b25b445c.392440ba-2841-42da-9eae-3624c032300b?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.56378.14481391283536320.2e278a9d-b63d-454a-a60e-ac81b25b445c.74cc5596-f1c5-4d33-8819-fc4fe7907982?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/totally-reliable-delivery-service/9NZG72SH3H4W"
     },
@@ -6016,11 +6027,11 @@
         "releaseDate": "30/11/2021",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/townscaper/9NFM39PSFXJD",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.47144.13596818197886835.587a1f17-af5b-48c5-acec-b287c3694c3b.f9e5ab95-f8bc-437e-917a-c38200963ac4?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.47144.13596818197886835.587a1f17-af5b-48c5-acec-b287c3694c3b.f9e5ab95-f8bc-437e-917a-c38200963ac4?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.54762.13596818197886835.587a1f17-af5b-48c5-acec-b287c3694c3b.a0c7c160-9ebb-47d9-8c3a-0c5cd66c6e9c?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/townscaper/9NFM39PSFXJD"
     },
@@ -6035,11 +6046,11 @@
         "releaseDate": "18/09/2019",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/trailmakers/9NSFGM8J6MBJ",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.4351.14364758607471359.e2225a2a-e6f7-44b1-a6a4-afd25f220f1c.17b9e5c5-fee2-401c-b74d-45d15133de94?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.4351.14364758607471359.e2225a2a-e6f7-44b1-a6a4-afd25f220f1c.17b9e5c5-fee2-401c-b74d-45d15133de94?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.41211.14364758607471359.e2225a2a-e6f7-44b1-a6a4-afd25f220f1c.744732a9-9341-4c4d-90ab-347251ab553f?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/trailmakers/9NSFGM8J6MBJ"
     },
@@ -6053,11 +6064,11 @@
         "releaseDate": "06/09/2022",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/train-sim-world-3-standard-edition/9PN99PX1P1LX",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.32810.13824994608911844.30135c6c-1c23-48e7-9923-7dd883c953d1.9a8b0171-e7a4-4598-a31d-df29e31f7bbf?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.32810.13824994608911844.30135c6c-1c23-48e7-9923-7dd883c953d1.9a8b0171-e7a4-4598-a31d-df29e31f7bbf?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.9997.13824994608911844.30135c6c-1c23-48e7-9923-7dd883c953d1.f89e5d43-1995-4aae-a812-365456f24cac?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/train-sim-world-3-standard-edition/9PN99PX1P1LX"
     },
@@ -6072,11 +6083,11 @@
         "releaseDate": "05/05/2022",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/trek-to-yomi/9MTCRVZQN3GV",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.109.13810431892468749.e5f7414c-2e05-4304-bb90-5df4b5221508.1f107c06-f879-4933-b58c-1a5dd881b421?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.109.13810431892468749.e5f7414c-2e05-4304-bb90-5df4b5221508.1f107c06-f879-4933-b58c-1a5dd881b421?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.14387.13810431892468749.e5f7414c-2e05-4304-bb90-5df4b5221508.f44bc585-93ed-428b-80e5-d5512e138cdc?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/trek-to-yomi/9MTCRVZQN3GV"
     },
@@ -6091,11 +6102,11 @@
         "releaseDate": "26/09/2019",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/tropico-6/C4KBHNHRPLN6",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.55829.66702598861173481.ab28a26d-e732-407f-b1fc-11b3cc0e41c0.04387f94-cdc6-4402-a538-4c0f0cb4049f?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.55829.66702598861173481.ab28a26d-e732-407f-b1fc-11b3cc0e41c0.04387f94-cdc6-4402-a538-4c0f0cb4049f?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.40705.66702598861173481.ab28a26d-e732-407f-b1fc-11b3cc0e41c0.b11d7c8c-dc21-40d5-92e3-cf5c6186dc9b?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/tropico-6/C4KBHNHRPLN6"
     },
@@ -6110,12 +6121,12 @@
         "releaseDate": "31/12/2799",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/turbo-golf-racing-game-preview/9N6781PMXC02",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.8752.14023533452078841.747fa65d-a94d-4613-a65d-e170645a3c1f.4ec3d3fd-6b93-4f06-827b-de4cf2a1f042?w=%i&h=%i",
-        "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.11425.14023533452078841.747fa65d-a94d-4613-a65d-e170645a3c1f.7d23a9fc-be55-4462-976c-96c849f401b9?h=%i&format=jpg",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.14858.14023533452078841.0a070564-c3f5-4559-a3c5-4716a27fd966.261f72e9-fe07-43e9-8305-d6fd84946a46?w=%i&format=jpg",
+        "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.36160.14023533452078841.0a070564-c3f5-4559-a3c5-4716a27fd966.2f925346-dbf4-458c-a58f-3ebb42f73c50?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/turbo-golf-racing-game-preview/9N6781PMXC02"
     },
     {
@@ -6129,11 +6140,11 @@
         "releaseDate": "18/04/2022",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/turnip-boy-commits-tax-evasion/9N0T8V0R7MBC",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.28759.13918938342247004.3a4e9214-ba82-4550-b1da-17c3eefbdfa4.a7fff141-6ce1-4395-91f5-8d4f8924404d?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.28759.13918938342247004.3a4e9214-ba82-4550-b1da-17c3eefbdfa4.a7fff141-6ce1-4395-91f5-8d4f8924404d?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.24911.13918938342247004.3a4e9214-ba82-4550-b1da-17c3eefbdfa4.3640c62d-df2c-42fc-a4a2-5d18ec92cfaf?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/turnip-boy-commits-tax-evasion/9N0T8V0R7MBC"
     },
@@ -6148,11 +6159,11 @@
         "releaseDate": "09/08/2022",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/two-point-campus/9PCW1SMN9RGG",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.46969.14161945646118465.4c1e1eb1-a1ec-49c5-b06d-8386c15bcbf3.6b016067-8e4a-4985-b34e-1704a4fed711?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.11253.14161945646118465.9d38b01a-1bf4-467b-8a2e-4833b374988e.1495baa8-c740-42db-a01a-765159e9c94d?w=%i&format=jpg",
         "gameImageUrl": "https:AAAAIGZ0eXBhdmlmAAAAAGF2aWZtaWYxbWlhZk1BMUIAAADybWV0YQAAAAAAAAAoaGRscgAAAAAAAAAAcGljdAAAAAAAAAAAAAAAAGxpYmF2aWYAAAAADnBpdG0AAAAAAAEAAAAeaWxvYwAAAABEAAABAAEAAAABAAABGgAAEvMAAAAoaWluZgAAAAAAAQAAABppbmZlAgAAAAABAABhdjAxQ29sb3IAAAAAamlwcnAAAABLaXBjbwAAABRpc3BlAAAAAAAAA8AAAAIcAAAAEHBpeGkAAAAAAwgICAAAAAxhdjFDgQQMAAAAABNjb2xybmNseAABAAEAAYAAAAAXaXBtYQAAAAAAAAABAAEEAQKDBAAAEvttZGF0EgAKChkme/hvogICAwgy4iUQ3ADDDDEAgkD0uJloL/IWGSkZEGwVSjLSqtILBrBvhRKu/6G75+rbd8CBGI6qRciStZmCl66cJxpKxnVsXUEnyN2OBSyFEgAn/xbYB63xcP1qMhb4z6vBJAzl22YDQxowxfnTTsJvEc7jHtpQtRO8zXIkxH5FOSkKZgnLoocuWmsyLCeBMQ/Y2CfCcXFBGLAL5Od9gZwYKKyLD2DkdggKfyFlsS9eYivYaecJ6dPwWnfq/jtOpSva5kgf4m90Tbk18tvO36SZdWw9bcVSYZMbXpUICh1L8i4ikoY8o4EBlbTnA+dBj1gKRSm+ydBSv30aoFTZDhrS879mxefVyRJgymecRhfHObIgpnhmmih/EVR6b3ywnBHOPzV9DG7idFy3f3ev01QzSIiAoMO7sX+R9juuNPuo/T3GmNt5vXMctoZgStYZ6N8M/hqa7OFLHMSPVc0KsW88yMb9lCFAdl3dus/YG5dpyV356GImj5iuvb0AdBMG1KNqHSLTMlSb6W9jpbIimiNTSAr3A03SPa3tV0YoqN72wMto6z33nyD9Rxtjr+eV+xarO+0XzL6gGhvxYWvOOCnEIkEuF1LFQsqbFhxel2CXIGQJ685Y94pmXVjFIeAk9m7UlYRN4YsvYEqh3atflxyBVYG3LLJejL/l/2rIsSe1qtP3AQfAFbGjVSt42P6iQhIEM9Ft7Yl0vnW65zsbZcOILNQ93ecTby3bvvN00klgQqfiMajeH/Us5xuX+Fz+AAAXqja8OB1suZ3rnbL+Y6HRCga4bfyfZMnaCOp/FvrENDdWqciuBX2htYA+0wjgksZ9wQm9VdoPrN80Mw1PIlz0Z/zcqgSW2pH3pLUI7ZuoFvhNP3WEAw1csgbk0hmeAp4PLUNhz/M3/y0mWYF1I1y1grofKEHSZwxPg1wcB/kI/kVBt5OMrGlfcbmHogib+dQHwch/Lnzc1Uto4Kh3Kukat+ArF8vAnP2EO5Ko2jQYnC6/b/W00k9DogEiJQKBsv410VrDAiW/lCBAvqwJMD+f9PZcxc0/zrirz/5O+I2iREATjE1TD68QWnha05B1w+dWFkPplo5UcuKkTySgri3pdDmIbasDt3nYFiD58zL8O3/2TmbULUf+DfPNkBzGtUFbaL206BI0SyiiEcDLqMxY3GCBvl5jrPID6ctR9H/8xhRZ+p3sA2UgsQCYL7O/dxR57FIerX3l7QOpmkkVZLkc8Zq3bHCHrO2g+P8SV0gpdZNR7Jt6dUSPZQXsIWXInEwtha+SizSJRFIT82YJMwhQRM7RtrfjwwNt/disBRQZ4Fgt3yvbVf/gOXE9+a2Oj5UV/fs9/6R/sWA8ulTq2iPfuXWnVoYq8bmaeRgRg2mWOeotIxjl5Nvz7vbNjRwy2JGhwr7Tw4yf6A5UNNv1ODQXA4Lq92+fQ83EWPubkOw+ZsBN18Iw5Nawbgm0LmT0YByqkqSQQABykNU1MSqYcoGSGGi720FvEHyUinYPhlsmkef0Emj1kK7R08HmEflnpIGV/eMYgYnrxeA68qGGAU1VHWCsDd7nKAolXlOJJDecwr75P2AoaXRdIGJj9bCpFDjMIA69rlnBhsVoO3DQcA5EgwjMJiehDEJIi5ZDW4BKrPiVZhbEOKBFi9j1lHT0Q02NSsgoOcY6DUkkvCys7hvEWLHK603KbJgvLIix6SeTc3Z85diDrzyOPoB3FpwWrGwDYI6qtXMUMoWGHiqF8ndKfRMxapILkDKEwEl1TcLY9uYPTx7MBB1cYJEO26/TEyQrDom/t9AxzbvchhHn/s4cT6NIWKye5/Ax3/lQprrRSKHHhUXgZDHU8b55cGJvIOaPAAVU/OWSXvFJaJg7NAF59KLTs/QaQOY+XOkOrVckngjWfqptMTt7F14By9thqXTzB2yJw+26DbaRf8Q/AObcca5Bujoh9YH1SL3BlPElHhONTN78REUNH4JqSibgmMAaxDCTxjLLPOydVstEunniC6kySY6sZxtig3L885KY7seoxlxXtMEmvXSSaJfiV/r6Cgfe7IfRtWAxdpaCi3VGllDHD9H0b5VHvk3QfeTlXyzoXRoecZmoC/GmCplwCFBjViOuEVsacMcqtJYcF57qAAYOYSrXXKvRkG6mwvF1QbaLRHLANnBJ/OSFVOt93MNLafQ11pJEa2qfoSm71MOy7lpMgLQ5Qqf/DA9I16DUQVxqEAsu48k4kKxrsIHMObWEQmWX4wrk44aebulLGATBlxMMBKF1kkv3pd68mZcRezooop+fh7/9LPbUurm7s8dxk8kpvYqFUkIpF8sLiOnmyEB/NyBlurTgV/yQD+zA0BLm4nO6QHxWDrfV41ZQAYghz/AXP9ikxlvHM6Xv/LMjKc1isyxMTLSRwIa2IoxCaFv6eWsnxFFpFSAejBD4t16+EJuQchYOrQ6Vt/n/al/Z/onRaZ+e1/SSYCegCrlMzjpolzqZrCjX3vaGI+RuQ7f8u0Gnp8ij6KNnPPWJA0gPv5fSUav+D8Rhb4zPmIfYcmvr8z0apIXbNA9cO47fJNYJ6CqHXTukpV4YarR9Q48tUPUKbi5q1fuEE9gKSRXa3GW4sd9EiLsOST/CsR10ouAUXVmcao8FNXgzNw3fCpvdk4EwNbsAY4po7KSRNV57rVAqY6Q/2xPRI9uvqFIEQuepUwAQoQH98uNlXz6ZO9OnKc/GZSoKs94LN8IuyPMTrDjoILvBeH8Ob9B3BNq4OwgLDL4hKq4zwIQMVms4CJDk311zy37RkS5fxDLddfw1A0s1fOsVwr63QeyllZpq8vTWZZWZBNICezB1+v4QiS4KHaJJyHlnbVeJB1WrUmqvSYKMm3SV2c2XtQoNW5A4ccQI3LqT5v9I/Z3ATGDMov35j95IxCx9ArKxYPt+JlHxesbpLXYXijz8XlVmoBlI+veHUAX+qhPX2ktDz+yabpDom/avarmkPt3ve2es+zyA9MfMZd7nIximUgqZNEBoKhtq56jAzx5iwblt1AXVaME1qdSgrFNREt+7TRInJ7VkzYeSDiH6i0dKe+tTgxejF6CZE5IU8KYYZABhY3kC/oaybwH1+ahxKLz3+FDUZH/XP2vjY8DIhq4dVuBJpHvadH2mE7nrVHsITPfdqtqpBd6fFPRqXlW+QuD0lRCa8ocnNqpdhSIqoC9SqdrwLtQIqAbj7AYNVhNp9HnJd5BSBdSskuCG/SBGVLeh+Mbb05+E9oU0VQb2DJNKUm5wsW/wR9B/JNSVej5stWVqomlHN+ZG7oL4kKM1ftyDqY/5/NoeDgpFSwyqsa1/M+IVnlK/jFmnBA0wxz5phnzmsCvFwO69Yw3o11fEw4/59zhO75WYX7AMrq3XGt8RL/kAKJzfChOYnxmJpe2YOKiU/MbxhKFxnqt4/aA8nGjOz80PBaFx1B/BqBriBmg1Cdvdtt668/GQufmcALI5esAobu0QPFaT9mWtbYUlxPfp1vP9XraiyWL2OQ897rcjBBBgDo6iw5NJjFF+kzx9UvZEzNF1ZEvYaksTNzP94HXgx6IukDGf5MKwUsubgmn0ozatMNqi1ECQnsf1xkmnTT/wa0i48JJeCf1QBps2b88aw4ZMwq8OEbFqngpuqq/cUvQkP8mX84ABfcoEWjDdPaKkrEquOXbDf/7wddVo7JgKZvcdXFhtmp5mSLXUal9hTDVvcpFjxL111GCryDjLkzajV3N0mO5T1feP1XPIPeIbvX/Dm4LSSEhBgq8WcmviCbHhkVZcYZAR0DeCfaGH4gkTKS3u2tGZWEFVMQDhqm/fZRNroLa7mrd62bJkZnyMUwsDOxUnCu0H0pA3DgQLsj79aYMgzBDGbJIIHl79PFzRULrJWaUP7Hr2LRBCgXXVNY7/q+kZ5/4uh+epdFlaeQk1bewxjJjVFLNYGYJV6u+wb8wHLjIdykYIiRWrgvy45GK0iOGVD7aCHVc1rlLTrrrUF8qFclPi1liqnTRhRs8fC87i+tjteCSlOH1hijdkyFyEg9QY7wedQ8cnz1hAa47MLpDBH/418seOjYm2NJ6HQSu4PA1uggd3OXMRp2nAMvxGwnTWFZ1yoauZeUKwlu8UoOOwzzJK+9RcjhcN1cTo8vjq73jW0y9aJKSnmT2lQ8HtR0rKJovkgOkHS3uM25OTTxX5owx32w8N+rZnjaCIiOqrPRr95v2BW/0FTgjZjAklwz9vycjH4d/GeKW0HOthccqLQsFoUUFOpwrRcXElWOnzRm+4N+XmbSZe+XtQ23W7ywh6uER+nWl9/24Fc0bPSNaraju7EJR9Ro8E0QPcq2M9vPOECihAVI8T12a4T92OpPk0F7jq749ITIEWqxZdHiJGwkkKI86TNGag5tlT23B6YRyCMUNeShBT0hYUkOrxTTxXrMI+gtNfWTKTxc7oUDATM/E4qE8MgqFOkaCc+oEPXaheSjXKes+31+pe9Hda3u2ORvx5vM9Ds0CMd7cCl1QsyeORBAgheisWLkPtGdowkL2KsX42BH7sCb4a6x/RtJHAY581BcUJrbeBq7o7I+YVpIcQtP004H06AqLmCedddfHcySVl5FAUtxLRszgJJjuL9hxLZvKPTjL3db5PuFJYG+oI0t9IqBBd3AtCX00xiqtWEajQE548rm5MLFR9dwGAEjRGmyBVnOZDBId1TiLyymuqCrilcYJ3bz7xGR8HGgxVrRiT44NNGIprOkQv9kb3Fy8ZllXFMa8h7rFC3qVg2M3p6mVCOMGNVBML5kyXyLQ7CNbgQDVc9ep49XcP+Ij2uKORHUZ3SfDJZd57oR0NNwA5nzNOLOc+wlwYAaRSOHKIKh9UM5RdqZy5lU2kNWOwfovvoReYNWm6P80s3/r8PQ/n3MutbsEGJ2mWBSslGdo+JH6pYd2hg/rlISngXndT0GwzocFRcmjddpXY67OV0sUaTepGzWr3ntujW0/IJRC1Zej0SXDaiR+e9VyE7rgTuoU2gEiU0N5Lqbr5tZuqx8TGXs3cQLyZpC6wH+LdyTF4J0fmDlIBphe7r5IDCRBG8eOXuZRXGSoGPYaOmA2PUJefh7fVflc0LG36i5MQmF/KI7fTxavg+8/kH4gIh3S40X5V0sPxsNKPfNKJwKE2RPVXIqHzzWyPqEqwAI8PZZb1RrnI9nzlDH5UF3tIH4Cibmn0iifDFXW96ZT5fE57MAXFk90gfVIGCfg4AuR4aM5j0gr/LCPd3N6BDUGN1NelVsHfjf3J+sdlBhSHN31bcMDLqLXz8dGrKRAK/MWOhF2OhmanABLLp6+pDkzNItsgH08ZyyictMPUQuHIG+bBQlF53b0fbgQIZ5Q4O72zfCMDEz55qAIvc0NBuJIZumsUxUe7Dk0LLqjzZdfMivzdNmBJpATZOf72RZOHaUHehpecqOLXIk83Vsn0u77qIiJDsIXz45stg1ApnELGWM0VEJvaK1cD2WSJ2n8U/Phe9ynHcCNTjeSblB41b5icDZw0TNmU3QKtNovfZ8UUwgMNsbgxh+UCxhDYwfn3tfMk+iRRHn9pCougsMx/+0ungeJkxnZD5Z1Ux9G1vuTO6b0AeFnuNUoLpuo2K+Zu9RkI1rBfFFosSzJkk/G3REuZHMPQ5/WghwR0T848P3BbNsEJQWXao/PdtGXVN1OTuauMJVZFwSX98ndPmSQIbnB/ATIeKecx0+HLq7uxCzEFkmD3Cc+g4+jYg9YwBCyveCxRcOeDh5Xk5S18jBMbM2oDvLR9pKgEo1kaG4FJeH9vIVQbniQcqemdr86ZG8MzXlyZjfU8+rFrYToSRpCxV217GlWcf1tJEicM9IoMr2OxW254PlBgMfrHJc89wfmzHhs5+Bs82zEl8OiwGTh0GgxCDrhZ/z6RRywPG2aG4BcsGo6RGrp0ggzt8UtJSfvtpWcIq8iiKVcwTRzBW/UB534GohOljBPEQ+3z5sR7CpyW/aUCTbLtvBgg32osefXBOh9+KVhJI4dSM5OqIie2ohUk1l9wFEE3csezdgrydGTzeejGTbARd0Vlg8+5aa8Pjp52qR3SAtKrMYhV4pnRVKQNj5Q+cG9SCQ9mgSEjSHIVn7QAEFsnqvuMcEbfq/kcuT/zW7TLvJ4ttp8VsABhQBIss2uO2Sr8uzBnfcVGSvQJOux2uKF+tESgB9uFNQ6dNnr4UXGAa/FVoA+BWavJEsUOtafDzsuvypNyhqsN2xdaGxSYF8W/oI9AWcfrT8uxEoKGRWG+A8OkI2e0eq5RAudLh6rrlLh780d8TxP58UhGod6pOBKroGpmVj3ST9geZ67UfueS+bLv/Pu5Fhpv2/F4F3ZSzgJxIFnMZhuqmzEpCo0ezxMEQfO0TQuvQijElCxc9l0dJz1hAqslxGSKpjS7JnoGha7MHEvczLnl0d4hu+6gN2eIC8nGKS0oV8u5x/oZP6QpriEmZfPI9am/mQ2%iB",
         "storeUrl": "https://www.xbox.com/games/store/two-point-campus/9PCW1SMN9RGG"
     },
@@ -6166,11 +6177,11 @@
         "releaseDate": "16/05/2022",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/umurangi-generation-special-edition/9PKLF2W8J0TF",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.13391.14260645465200380.af962a53-8815-4214-9dc3-7e92e8adec2b.66e92f9c-1ebb-422c-ac21-b4eaac54bd52?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.13391.14260645465200380.af962a53-8815-4214-9dc3-7e92e8adec2b.66e92f9c-1ebb-422c-ac21-b4eaac54bd52?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.43834.14260645465200380.af962a53-8815-4214-9dc3-7e92e8adec2b.3aecb4f6-e278-4387-b2ae-3d654b5ce62c?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/umurangi-generation-special-edition/9PKLF2W8J0TF"
     },
@@ -6184,32 +6195,13 @@
         "releaseDate": "15/03/2021",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/undertale/9PJGGX9XJXPB",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.15028.14216942822196343.dfa45b94-960e-4595-b2be-f54c2f268b7a.1e441b9e-11a6-45a5-8d5c-2d563a19439a?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.15028.14216942822196343.dfa45b94-960e-4595-b2be-f54c2f268b7a.1e441b9e-11a6-45a5-8d5c-2d563a19439a?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.31988.14216942822196343.dfa45b94-960e-4595-b2be-f54c2f268b7a.1e119400-e116-4a10-a916-1160bdd981a5?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/undertale/9PJGGX9XJXPB"
-    },
-    {
-        "gameTitle": "Undungeon",
-        "gamePublisher": "tinyBuild",
-        "gameDeveloper": "Laughing Machines",
-        "gameGenres": [
-            "A\u00e7\u00e3o e aventura",
-            "RPG"
-        ],
-        "releaseDate": "18/11/2021",
-        "extraGameProperties": {
-            "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
-        },
-        "xcloudUrl": "https://www.xbox.com/%s/play/games/undungeon/9N55W5HG0DSG",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.21160.13969309302998441.31cbae08-c7d3-436f-b6a4-9ef04acee0f9.b0a90bd0-77b3-45b1-84fe-2dfb49131365?w=%i&h=%i",
-        "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.26421.13969309302998441.31cbae08-c7d3-436f-b6a4-9ef04acee0f9.b75f7f94-a229-4b9d-8723-58a9f189aa10?h=%i&format=jpg",
-        "storeUrl": "https://www.xbox.com/games/store/undungeon/9N55W5HG0DSG"
     },
     {
         "gameTitle": "Unpacking",
@@ -6222,11 +6214,11 @@
         "releaseDate": "02/11/2021",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/unpacking/9NH5HN11FG4M",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.1461.13636460453065260.a236863a-02a2-47fd-bfee-b7b301312a6e.adcf4c68-73b9-45a5-9304-0c3d43be83f8?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.1461.13636460453065260.a236863a-02a2-47fd-bfee-b7b301312a6e.adcf4c68-73b9-45a5-9304-0c3d43be83f8?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.13051.13636460453065260.ecf51b77-0a2c-413e-97f7-3aacd9282ab3.dd5a85c1-2cf9-4128-850a-e931036fb1b6?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/unpacking/9NH5HN11FG4M"
     },
@@ -6240,11 +6232,11 @@
         "releaseDate": "08/06/2018",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/unravel-two/C4VKLMG1HLZW",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.6886.67435278791875206.d60b3a6b-61b2-4afb-9c4c-453efe4ef48e.5851cf69-55b2-4383-a019-fb601fb993db?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.6886.67435278791875206.d60b3a6b-61b2-4afb-9c4c-453efe4ef48e.5851cf69-55b2-4383-a019-fb601fb993db?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.14989.67435278791875206.d60b3a6b-61b2-4afb-9c4c-453efe4ef48e.5e1c0d2f-eb8d-4d17-9b6f-78e60406e303?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/unravel-two/C4VKLMG1HLZW"
     },
@@ -6258,13 +6250,31 @@
         "releaseDate": "27/04/2022",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/unsouled/9N7KBCL0NC5H",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.34215.14067847727673942.bc35e2b5-e9f7-46d2-88a7-ec8582f969a9.872121c0-6e54-4b4d-bfca-e00302c1a246?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.34215.14067847727673942.bc35e2b5-e9f7-46d2-88a7-ec8582f969a9.872121c0-6e54-4b4d-bfca-e00302c1a246?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.49381.14067847727673942.0fb11748-9210-454a-9fa8-46519e6e34f4.60602cb3-9f1e-488e-b1f7-cbdec4a850a2?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/unsouled/9N7KBCL0NC5H"
+    },
+    {
+        "gameTitle": "Vampire Survivors",
+        "gamePublisher": "Poncle",
+        "gameDeveloper": "Poncle",
+        "gameGenres": [
+            "A\u00e7\u00e3o e aventura"
+        ],
+        "releaseDate": "19/10/2022",
+        "extraGameProperties": {
+            "isInGamePass": true,
+            "controllerSupport": true,
+            "touchControllerSupport": true
+        },
+        "xcloudUrl": "https://www.xbox.com/%s/play/games/vampire-survivors/9PD5BM2Z8C4L",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.60062.14160661575041057.92e444db-ebb1-4665-8e17-3322a7fae71d.e4e983fc-203e-4894-87ac-a7cd35993538?w=%i&format=jpg",
+        "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.47160.14160661575041057.af51c8f8-c3a4-4083-ac92-327aba6e43ea.c0c2df5d-5e47-450b-bc69-c84ba3b36a8d?h=%i&format=jpg",
+        "storeUrl": "https://www.xbox.com/games/store/vampire-survivors/9PD5BM2Z8C4L"
     },
     {
         "gameTitle": "Viva Pi\u00f1ata: TIP",
@@ -6276,31 +6286,13 @@
         "releaseDate": "10/08/2009",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/viva-pi%C3%B1ata-tip/BS1NPTPJGD4G",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.65381.69467662407886849.eb318d40-1e77-4848-b633-b9ee445d2f63.2bb50256-bcc1-477e-8fd6-4780b64a6cc0?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.65381.69467662407886849.eb318d40-1e77-4848-b633-b9ee445d2f63.2bb50256-bcc1-477e-8fd6-4780b64a6cc0?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.22237.69467662407886849.eb318d40-1e77-4848-b633-b9ee445d2f63.027e79d7-0592-4087-9b54-7c795ea9fc02?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/viva-pi%C3%B1ata-tip/BS1NPTPJGD4G"
-    },
-    {
-        "gameTitle": "Warhammer 40,000: Battlesector",
-        "gamePublisher": "Slitherine Ltd.",
-        "gameDeveloper": "Black Lab Games",
-        "gameGenres": [
-            "Estrat\u00e9gia"
-        ],
-        "releaseDate": "01/12/2021",
-        "extraGameProperties": {
-            "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
-        },
-        "xcloudUrl": "https://www.xbox.com/%s/play/games/warhammer-40000-battlesector/9P4FCZR21QQK",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.26109.14590233302827538.70136681-c41b-42f8-a975-a9edb5e9d3f3.c591cd02-9837-4fe4-99a1-42b90cfba64e?w=%i&h=%i",
-        "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.5032.14590233302827538.76c8df10-a5c4-4247-823c-21735ffe3473.673d847e-c6f8-4786-803c-3ee7f13f4219?h=%i&format=jpg",
-        "storeUrl": "https://www.xbox.com/games/store/warhammer-40000-battlesector/9P4FCZR21QQK"
     },
     {
         "gameTitle": "Wasteland 2: Director's Cut",
@@ -6313,11 +6305,11 @@
         "releaseDate": "12/10/2015",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/wasteland-2-director's-cut/C521HDXRTS7F",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.44620.13602252643452986.79361d33-7a18-4554-8a50-66b60d3712e6.7ed73918-7955-45fe-9456-d1fe66a57a9e?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.44620.13602252643452986.79361d33-7a18-4554-8a50-66b60d3712e6.7ed73918-7955-45fe-9456-d1fe66a57a9e?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.1978.13602252643452986.79361d33-7a18-4554-8a50-66b60d3712e6.74ed384a-6901-47e0-a185-e8be46be306c?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/wasteland-2-director's-cut/C521HDXRTS7F"
     },
@@ -6331,11 +6323,11 @@
         "releaseDate": "27/08/2020",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/wasteland-3/BQ9T0JF0D3L4",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.31983.69010346493633739.074410cb-38ab-4f48-b6fe-0ffa69c89fa9.b1e9bf9f-f41e-4384-9a25-748d0b18fedd?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.31983.69010346493633739.074410cb-38ab-4f48-b6fe-0ffa69c89fa9.b1e9bf9f-f41e-4384-9a25-748d0b18fedd?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.5558.69010346493633739.074410cb-38ab-4f48-b6fe-0ffa69c89fa9.6fbe0426-d9be-4472-bfad-0344480efbb8?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/wasteland-3/BQ9T0JF0D3L4"
     },
@@ -6350,11 +6342,11 @@
         "releaseDate": "25/02/2020",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/wasteland-remastered/9NGH1FK0RJGL",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.33255.13650100416089145.e9c63102-735a-40a7-b414-10693b469ff1.9d33c3ba-38af-4676-93e6-282f0280d212?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.33255.13650100416089145.e9c63102-735a-40a7-b414-10693b469ff1.9d33c3ba-38af-4676-93e6-282f0280d212?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.60150.13650100416089145.e9c63102-735a-40a7-b414-10693b469ff1.bd9c07a7-be22-4688-89db-b2a8a38df68d?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/wasteland-remastered/9NGH1FK0RJGL"
     },
@@ -6368,11 +6360,11 @@
         "releaseDate": "14/11/2016",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/watch-dogs2/BSXLFN5QQZSC",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.15364.69997608528322872.06dc9610-5c4e-484e-b028-58ad215e637a.ab2ff32b-6ec5-40b7-9492-471c12708bf0?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.15364.69997608528322872.06dc9610-5c4e-484e-b028-58ad215e637a.ab2ff32b-6ec5-40b7-9492-471c12708bf0?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.38484.69997608528322872.06dc9610-5c4e-484e-b028-58ad215e637a.29a8afc9-c3c7-4b3d-8e9f-f1b2858db4f8?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/watch-dogs2/BSXLFN5QQZSC"
     },
@@ -6386,11 +6378,11 @@
         "releaseDate": "09/08/2018",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/we-happy-few/BPR2TBS2KMQJ",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.40710.68143759676978415.617fe4d2-4978-4b4d-9e04-cba4cf86d432.4820a8ef-b0f3-4fcd-ab0a-6a76014c0c3c?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.40710.68143759676978415.617fe4d2-4978-4b4d-9e04-cba4cf86d432.4820a8ef-b0f3-4fcd-ab0a-6a76014c0c3c?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.40691.68143759676978415.617fe4d2-4978-4b4d-9e04-cba4cf86d432.2ed3053f-3072-44f6-86d2-37c6c2f45087?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/we-happy-few/BPR2TBS2KMQJ"
     },
@@ -6405,11 +6397,11 @@
         "releaseDate": "31/03/2022",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/weird-west/9P0B86JN5X28",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.6486.14464239229931947.92218744-a2d3-4d4d-b2e8-a96385319eb0.24828d5c-9647-4f3e-8dde-acd52b333355?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.6486.14464239229931947.92218744-a2d3-4d4d-b2e8-a96385319eb0.24828d5c-9647-4f3e-8dde-acd52b333355?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.51072.14464239229931947.92218744-a2d3-4d4d-b2e8-a96385319eb0.9c407874-ff5f-496a-b32a-2fa8abb8aa37?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/weird-west/9P0B86JN5X28"
     },
@@ -6424,11 +6416,11 @@
         "releaseDate": "20/01/2022",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/windjammers-2/9N232RBCFR2G",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.23620.13960214545711625.430c5652-1978-4e19-92b1-8e901cdd420c.3dffa413-653f-4895-9baf-693821a21ac5?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.23620.13960214545711625.430c5652-1978-4e19-92b1-8e901cdd420c.3dffa413-653f-4895-9baf-693821a21ac5?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.61598.13960214545711625.430c5652-1978-4e19-92b1-8e901cdd420c.0f182277-d985-4e95-9d77-f006eebd634e?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/windjammers-2/9N232RBCFR2G"
     },
@@ -6443,11 +6435,11 @@
         "releaseDate": "19/05/2014",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/wolfenstein-the-new-order/BT9FFLG51VVG",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.5170.70764866595776237.49bcb933-4bfd-4b64-a764-f2ef10fde8d5.a78a2b99-81e7-4ed0-8d98-c1f2dc453506?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.5170.70764866595776237.49bcb933-4bfd-4b64-a764-f2ef10fde8d5.a78a2b99-81e7-4ed0-8d98-c1f2dc453506?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.18996.70764866595776237.49bcb933-4bfd-4b64-a764-f2ef10fde8d5.70d9caae-ca16-4b21-871a-f8c28349f7d9?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/wolfenstein-the-new-order/BT9FFLG51VVG"
     },
@@ -6461,11 +6453,11 @@
         "releaseDate": "04/05/2015",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/wolfenstein-the-old-blood/BPV4GXTDCNSH",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.20849.68153994599451024.9f03bc8c-e4ac-4d66-9e8a-c64ec1810cc0.92b342ca-5481-4109-8b6f-f1b0d2940433?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.20849.68153994599451024.9f03bc8c-e4ac-4d66-9e8a-c64ec1810cc0.92b342ca-5481-4109-8b6f-f1b0d2940433?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.38487.68153994599451024.9f03bc8c-e4ac-4d66-9e8a-c64ec1810cc0.42e137be-f756-4ecb-933d-3e96b221e1d1?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/wolfenstein-the-old-blood/BPV4GXTDCNSH"
     },
@@ -6480,11 +6472,11 @@
         "releaseDate": "25/07/2019",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/wolfenstein-youngblood/C421ZX7RCG0W",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.22779.66937225626631404.377c6044-13d5-4b96-8957-5b00b3f14438.9112b323-c42b-4072-a1ea-11ce9cfd66fc?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.22779.66937225626631404.377c6044-13d5-4b96-8957-5b00b3f14438.9112b323-c42b-4072-a1ea-11ce9cfd66fc?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.52745.66937225626631404.377c6044-13d5-4b96-8957-5b00b3f14438.7172a72d-7f7c-4a1c-aec9-62b3d0701fc0?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/wolfenstein-youngblood/C421ZX7RCG0W"
     },
@@ -6499,11 +6491,11 @@
         "releaseDate": "26/10/2017",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/wolfenstein-ii-the-new-colossus/C4LLMHFQ1BXQ",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.2334.66681981221768345.76a0e962-989c-428d-a0d4-5b11187fa034.220af923-7124-4d46-98f3-78cc10b9492b?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.2334.66681981221768345.76a0e962-989c-428d-a0d4-5b11187fa034.220af923-7124-4d46-98f3-78cc10b9492b?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.3811.66681981221768345.76a0e962-989c-428d-a0d4-5b11187fa034.52e87a8b-c27a-44c8-91fb-28098b23466e?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/wolfenstein-ii-the-new-colossus/C4LLMHFQ1BXQ"
     },
@@ -6517,11 +6509,11 @@
         "releaseDate": "22/08/2016",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/worms-w.m.d/C4BZ7X545J1T",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.41175.66550732470485128.fb64d8d0-8d1a-4592-beb7-c3634d551b35.69e1f605-b5b2-4401-a2f4-223edb7879e9?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.41175.66550732470485128.fb64d8d0-8d1a-4592-beb7-c3634d551b35.69e1f605-b5b2-4401-a2f4-223edb7879e9?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.44251.66550732470485128.fb64d8d0-8d1a-4592-beb7-c3634d551b35.de506352-7473-4e66-abc3-99f2c7a7cb2e?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/worms-w.m.d/C4BZ7X545J1T"
     },
@@ -6536,11 +6528,11 @@
         "releaseDate": "27/08/2019",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/wreckfest/BRJNRZ9N734V",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.64141.69762792333465121.4086c71f-fab9-4c14-b959-3e77164a74cf.27e4efda-6f6d-4d33-b636-4d6ef45396ea?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.64141.69762792333465121.4086c71f-fab9-4c14-b959-3e77164a74cf.27e4efda-6f6d-4d33-b636-4d6ef45396ea?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.26794.69762792333465121.4086c71f-fab9-4c14-b959-3e77164a74cf.6f7d7fb6-9c96-432b-8625-6749a1135a91?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/wreckfest/BRJNRZ9N734V"
     },
@@ -6554,11 +6546,11 @@
         "releaseDate": "25/02/2020",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/yakuza-0/9NPP17LHJ3MK",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.60688.13785223586843168.612c6166-3afd-413c-9b13-549ae975f01e.dd033b47-50aa-4bb9-a080-a3012123e470?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.60688.13785223586843168.612c6166-3afd-413c-9b13-549ae975f01e.dd033b47-50aa-4bb9-a080-a3012123e470?w=%i&format=jpg",
         "gameImageUrl": "https:AAAAIGZ0eXBhdmlmAAAAAGF2aWZtaWYxbWlhZk1BMUIAAADybWV0YQAAAAAAAAAoaGRscgAAAAAAAAAAcGljdAAAAAAAAAAAAAAAAGxpYmF2aWYAAAAADnBpdG0AAAAAAAEAAAAeaWxvYwAAAABEAAABAAEAAAABAAABGgAAEvMAAAAoaWluZgAAAAAAAQAAABppbmZlAgAAAAABAABhdjAxQ29sb3IAAAAAamlwcnAAAABLaXBjbwAAABRpc3BlAAAAAAAAA8AAAAIcAAAAEHBpeGkAAAAAAwgICAAAAAxhdjFDgQQMAAAAABNjb2xybmNseAABAAEAAYAAAAAXaXBtYQAAAAAAAAABAAEEAQKDBAAAEvttZGF0EgAKChkme/hvogICAwgy4iUQ3ADDDDEAgkD0uJloL/IWGSkZEGwVSjLSqtILBrBvhRKu/6G75+rbd8CBGI6qRciStZmCl66cJxpKxnVsXUEnyN2OBSyFEgAn/xbYB63xcP1qMhb4z6vBJAzl22YDQxowxfnTTsJvEc7jHtpQtRO8zXIkxH5FOSkKZgnLoocuWmsyLCeBMQ/Y2CfCcXFBGLAL5Od9gZwYKKyLD2DkdggKfyFlsS9eYivYaecJ6dPwWnfq/jtOpSva5kgf4m90Tbk18tvO36SZdWw9bcVSYZMbXpUICh1L8i4ikoY8o4EBlbTnA+dBj1gKRSm+ydBSv30aoFTZDhrS879mxefVyRJgymecRhfHObIgpnhmmih/EVR6b3ywnBHOPzV9DG7idFy3f3ev01QzSIiAoMO7sX+R9juuNPuo/T3GmNt5vXMctoZgStYZ6N8M/hqa7OFLHMSPVc0KsW88yMb9lCFAdl3dus/YG5dpyV356GImj5iuvb0AdBMG1KNqHSLTMlSb6W9jpbIimiNTSAr3A03SPa3tV0YoqN72wMto6z33nyD9Rxtjr+eV+xarO+0XzL6gGhvxYWvOOCnEIkEuF1LFQsqbFhxel2CXIGQJ685Y94pmXVjFIeAk9m7UlYRN4YsvYEqh3atflxyBVYG3LLJejL/l/2rIsSe1qtP3AQfAFbGjVSt42P6iQhIEM9Ft7Yl0vnW65zsbZcOILNQ93ecTby3bvvN00klgQqfiMajeH/Us5xuX+Fz+AAAXqja8OB1suZ3rnbL+Y6HRCga4bfyfZMnaCOp/FvrENDdWqciuBX2htYA+0wjgksZ9wQm9VdoPrN80Mw1PIlz0Z/zcqgSW2pH3pLUI7ZuoFvhNP3WEAw1csgbk0hmeAp4PLUNhz/M3/y0mWYF1I1y1grofKEHSZwxPg1wcB/kI/kVBt5OMrGlfcbmHogib+dQHwch/Lnzc1Uto4Kh3Kukat+ArF8vAnP2EO5Ko2jQYnC6/b/W00k9DogEiJQKBsv410VrDAiW/lCBAvqwJMD+f9PZcxc0/zrirz/5O+I2iREATjE1TD68QWnha05B1w+dWFkPplo5UcuKkTySgri3pdDmIbasDt3nYFiD58zL8O3/2TmbULUf+DfPNkBzGtUFbaL206BI0SyiiEcDLqMxY3GCBvl5jrPID6ctR9H/8xhRZ+p3sA2UgsQCYL7O/dxR57FIerX3l7QOpmkkVZLkc8Zq3bHCHrO2g+P8SV0gpdZNR7Jt6dUSPZQXsIWXInEwtha+SizSJRFIT82YJMwhQRM7RtrfjwwNt/disBRQZ4Fgt3yvbVf/gOXE9+a2Oj5UV/fs9/6R/sWA8ulTq2iPfuXWnVoYq8bmaeRgRg2mWOeotIxjl5Nvz7vbNjRwy2JGhwr7Tw4yf6A5UNNv1ODQXA4Lq92+fQ83EWPubkOw+ZsBN18Iw5Nawbgm0LmT0YByqkqSQQABykNU1MSqYcoGSGGi720FvEHyUinYPhlsmkef0Emj1kK7R08HmEflnpIGV/eMYgYnrxeA68qGGAU1VHWCsDd7nKAolXlOJJDecwr75P2AoaXRdIGJj9bCpFDjMIA69rlnBhsVoO3DQcA5EgwjMJiehDEJIi5ZDW4BKrPiVZhbEOKBFi9j1lHT0Q02NSsgoOcY6DUkkvCys7hvEWLHK603KbJgvLIix6SeTc3Z85diDrzyOPoB3FpwWrGwDYI6qtXMUMoWGHiqF8ndKfRMxapILkDKEwEl1TcLY9uYPTx7MBB1cYJEO26/TEyQrDom/t9AxzbvchhHn/s4cT6NIWKye5/Ax3/lQprrRSKHHhUXgZDHU8b55cGJvIOaPAAVU/OWSXvFJaJg7NAF59KLTs/QaQOY+XOkOrVckngjWfqptMTt7F14By9thqXTzB2yJw+26DbaRf8Q/AObcca5Bujoh9YH1SL3BlPElHhONTN78REUNH4JqSibgmMAaxDCTxjLLPOydVstEunniC6kySY6sZxtig3L885KY7seoxlxXtMEmvXSSaJfiV/r6Cgfe7IfRtWAxdpaCi3VGllDHD9H0b5VHvk3QfeTlXyzoXRoecZmoC/GmCplwCFBjViOuEVsacMcqtJYcF57qAAYOYSrXXKvRkG6mwvF1QbaLRHLANnBJ/OSFVOt93MNLafQ11pJEa2qfoSm71MOy7lpMgLQ5Qqf/DA9I16DUQVxqEAsu48k4kKxrsIHMObWEQmWX4wrk44aebulLGATBlxMMBKF1kkv3pd68mZcRezooop+fh7/9LPbUurm7s8dxk8kpvYqFUkIpF8sLiOnmyEB/NyBlurTgV/yQD+zA0BLm4nO6QHxWDrfV41ZQAYghz/AXP9ikxlvHM6Xv/LMjKc1isyxMTLSRwIa2IoxCaFv6eWsnxFFpFSAejBD4t16+EJuQchYOrQ6Vt/n/al/Z/onRaZ+e1/SSYCegCrlMzjpolzqZrCjX3vaGI+RuQ7f8u0Gnp8ij6KNnPPWJA0gPv5fSUav+D8Rhb4zPmIfYcmvr8z0apIXbNA9cO47fJNYJ6CqHXTukpV4YarR9Q48tUPUKbi5q1fuEE9gKSRXa3GW4sd9EiLsOST/CsR10ouAUXVmcao8FNXgzNw3fCpvdk4EwNbsAY4po7KSRNV57rVAqY6Q/2xPRI9uvqFIEQuepUwAQoQH98uNlXz6ZO9OnKc/GZSoKs94LN8IuyPMTrDjoILvBeH8Ob9B3BNq4OwgLDL4hKq4zwIQMVms4CJDk311zy37RkS5fxDLddfw1A0s1fOsVwr63QeyllZpq8vTWZZWZBNICezB1+v4QiS4KHaJJyHlnbVeJB1WrUmqvSYKMm3SV2c2XtQoNW5A4ccQI3LqT5v9I/Z3ATGDMov35j95IxCx9ArKxYPt+JlHxesbpLXYXijz8XlVmoBlI+veHUAX+qhPX2ktDz+yabpDom/avarmkPt3ve2es+zyA9MfMZd7nIximUgqZNEBoKhtq56jAzx5iwblt1AXVaME1qdSgrFNREt+7TRInJ7VkzYeSDiH6i0dKe+tTgxejF6CZE5IU8KYYZABhY3kC/oaybwH1+ahxKLz3+FDUZH/XP2vjY8DIhq4dVuBJpHvadH2mE7nrVHsITPfdqtqpBd6fFPRqXlW+QuD0lRCa8ocnNqpdhSIqoC9SqdrwLtQIqAbj7AYNVhNp9HnJd5BSBdSskuCG/SBGVLeh+Mbb05+E9oU0VQb2DJNKUm5wsW/wR9B/JNSVej5stWVqomlHN+ZG7oL4kKM1ftyDqY/5/NoeDgpFSwyqsa1/M+IVnlK/jFmnBA0wxz5phnzmsCvFwO69Yw3o11fEw4/59zhO75WYX7AMrq3XGt8RL/kAKJzfChOYnxmJpe2YOKiU/MbxhKFxnqt4/aA8nGjOz80PBaFx1B/BqBriBmg1Cdvdtt668/GQufmcALI5esAobu0QPFaT9mWtbYUlxPfp1vP9XraiyWL2OQ897rcjBBBgDo6iw5NJjFF+kzx9UvZEzNF1ZEvYaksTNzP94HXgx6IukDGf5MKwUsubgmn0ozatMNqi1ECQnsf1xkmnTT/wa0i48JJeCf1QBps2b88aw4ZMwq8OEbFqngpuqq/cUvQkP8mX84ABfcoEWjDdPaKkrEquOXbDf/7wddVo7JgKZvcdXFhtmp5mSLXUal9hTDVvcpFjxL111GCryDjLkzajV3N0mO5T1feP1XPIPeIbvX/Dm4LSSEhBgq8WcmviCbHhkVZcYZAR0DeCfaGH4gkTKS3u2tGZWEFVMQDhqm/fZRNroLa7mrd62bJkZnyMUwsDOxUnCu0H0pA3DgQLsj79aYMgzBDGbJIIHl79PFzRULrJWaUP7Hr2LRBCgXXVNY7/q+kZ5/4uh+epdFlaeQk1bewxjJjVFLNYGYJV6u+wb8wHLjIdykYIiRWrgvy45GK0iOGVD7aCHVc1rlLTrrrUF8qFclPi1liqnTRhRs8fC87i+tjteCSlOH1hijdkyFyEg9QY7wedQ8cnz1hAa47MLpDBH/418seOjYm2NJ6HQSu4PA1uggd3OXMRp2nAMvxGwnTWFZ1yoauZeUKwlu8UoOOwzzJK+9RcjhcN1cTo8vjq73jW0y9aJKSnmT2lQ8HtR0rKJovkgOkHS3uM25OTTxX5owx32w8N+rZnjaCIiOqrPRr95v2BW/0FTgjZjAklwz9vycjH4d/GeKW0HOthccqLQsFoUUFOpwrRcXElWOnzRm+4N+XmbSZe+XtQ23W7ywh6uER+nWl9/24Fc0bPSNaraju7EJR9Ro8E0QPcq2M9vPOECihAVI8T12a4T92OpPk0F7jq749ITIEWqxZdHiJGwkkKI86TNGag5tlT23B6YRyCMUNeShBT0hYUkOrxTTxXrMI+gtNfWTKTxc7oUDATM/E4qE8MgqFOkaCc+oEPXaheSjXKes+31+pe9Hda3u2ORvx5vM9Ds0CMd7cCl1QsyeORBAgheisWLkPtGdowkL2KsX42BH7sCb4a6x/RtJHAY581BcUJrbeBq7o7I+YVpIcQtP004H06AqLmCedddfHcySVl5FAUtxLRszgJJjuL9hxLZvKPTjL3db5PuFJYG+oI0t9IqBBd3AtCX00xiqtWEajQE548rm5MLFR9dwGAEjRGmyBVnOZDBId1TiLyymuqCrilcYJ3bz7xGR8HGgxVrRiT44NNGIprOkQv9kb3Fy8ZllXFMa8h7rFC3qVg2M3p6mVCOMGNVBML5kyXyLQ7CNbgQDVc9ep49XcP+Ij2uKORHUZ3SfDJZd57oR0NNwA5nzNOLOc+wlwYAaRSOHKIKh9UM5RdqZy5lU2kNWOwfovvoReYNWm6P80s3/r8PQ/n3MutbsEGJ2mWBSslGdo+JH6pYd2hg/rlISngXndT0GwzocFRcmjddpXY67OV0sUaTepGzWr3ntujW0/IJRC1Zej0SXDaiR+e9VyE7rgTuoU2gEiU0N5Lqbr5tZuqx8TGXs3cQLyZpC6wH+LdyTF4J0fmDlIBphe7r5IDCRBG8eOXuZRXGSoGPYaOmA2PUJefh7fVflc0LG36i5MQmF/KI7fTxavg+8/kH4gIh3S40X5V0sPxsNKPfNKJwKE2RPVXIqHzzWyPqEqwAI8PZZb1RrnI9nzlDH5UF3tIH4Cibmn0iifDFXW96ZT5fE57MAXFk90gfVIGCfg4AuR4aM5j0gr/LCPd3N6BDUGN1NelVsHfjf3J+sdlBhSHN31bcMDLqLXz8dGrKRAK/MWOhF2OhmanABLLp6+pDkzNItsgH08ZyyictMPUQuHIG+bBQlF53b0fbgQIZ5Q4O72zfCMDEz55qAIvc0NBuJIZumsUxUe7Dk0LLqjzZdfMivzdNmBJpATZOf72RZOHaUHehpecqOLXIk83Vsn0u77qIiJDsIXz45stg1ApnELGWM0VEJvaK1cD2WSJ2n8U/Phe9ynHcCNTjeSblB41b5icDZw0TNmU3QKtNovfZ8UUwgMNsbgxh+UCxhDYwfn3tfMk+iRRHn9pCougsMx/+0ungeJkxnZD5Z1Ux9G1vuTO6b0AeFnuNUoLpuo2K+Zu9RkI1rBfFFosSzJkk/G3REuZHMPQ5/WghwR0T848P3BbNsEJQWXao/PdtGXVN1OTuauMJVZFwSX98ndPmSQIbnB/ATIeKecx0+HLq7uxCzEFkmD3Cc+g4+jYg9YwBCyveCxRcOeDh5Xk5S18jBMbM2oDvLR9pKgEo1kaG4FJeH9vIVQbniQcqemdr86ZG8MzXlyZjfU8+rFrYToSRpCxV217GlWcf1tJEicM9IoMr2OxW254PlBgMfrHJc89wfmzHhs5+Bs82zEl8OiwGTh0GgxCDrhZ/z6RRywPG2aG4BcsGo6RGrp0ggzt8UtJSfvtpWcIq8iiKVcwTRzBW/UB534GohOljBPEQ+3z5sR7CpyW/aUCTbLtvBgg32osefXBOh9+KVhJI4dSM5OqIie2ohUk1l9wFEE3csezdgrydGTzeejGTbARd0Vlg8+5aa8Pjp52qR3SAtKrMYhV4pnRVKQNj5Q+cG9SCQ9mgSEjSHIVn7QAEFsnqvuMcEbfq/kcuT/zW7TLvJ4ttp8VsABhQBIss2uO2Sr8uzBnfcVGSvQJOux2uKF+tESgB9uFNQ6dNnr4UXGAa/FVoA+BWavJEsUOtafDzsuvypNyhqsN2xdaGxSYF8W/oI9AWcfrT8uxEoKGRWG+A8OkI2e0eq5RAudLh6rrlLh780d8TxP58UhGod6pOBKroGpmVj3ST9geZ67UfueS+bLv/Pu5Fhpv2/F4F3ZSzgJxIFnMZhuqmzEpCo0ezxMEQfO0TQuvQijElCxc9l0dJz1hAqslxGSKpjS7JnoGha7MHEvczLnl0d4hu+6gN2eIC8nGKS0oV8u5x/oZP6QpriEmZfPI9am/mQ2%iB",
         "storeUrl": "https://www.xbox.com/games/store/yakuza-0/9NPP17LHJ3MK"
     },
@@ -6572,11 +6564,11 @@
         "releaseDate": "27/01/2021",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/yakuza-3-remastered/9N3460XCS8BC",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.21577.13944201124915616.56f9bc1a-1a43-4af0-bfb0-126636850d84.bf6d5086-d069-49e4-b394-b74c9377162e?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.21577.13944201124915616.56f9bc1a-1a43-4af0-bfb0-126636850d84.bf6d5086-d069-49e4-b394-b74c9377162e?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.1380.13944201124915616.56f9bc1a-1a43-4af0-bfb0-126636850d84.c81ddfac-1afd-42bd-9793-b761dfe02512?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/yakuza-3-remastered/9N3460XCS8BC"
     },
@@ -6590,11 +6582,11 @@
         "releaseDate": "27/01/2021",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/yakuza-4-remastered/9NXFD44B98P4",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.44004.14426508489866901.a44eacfe-7e1e-495c-8aa4-17ccfbaa45e8.d8dafb44-9f24-42cc-8198-709a508821a5?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.44004.14426508489866901.a44eacfe-7e1e-495c-8aa4-17ccfbaa45e8.d8dafb44-9f24-42cc-8198-709a508821a5?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.57797.14426508489866901.a44eacfe-7e1e-495c-8aa4-17ccfbaa45e8.69580778-9fdb-4216-b4a7-8fe701875340?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/yakuza-4-remastered/9NXFD44B98P4"
     },
@@ -6608,11 +6600,11 @@
         "releaseDate": "27/01/2021",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/yakuza-5-remastered/9NK23S9XBMZ6",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.3163.13665499948454255.6c2e1d5c-1a06-4839-a773-4e814ef1ff4b.c720fdee-85c1-4b0e-a8d3-bfed564f5bbf?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.3163.13665499948454255.6c2e1d5c-1a06-4839-a773-4e814ef1ff4b.c720fdee-85c1-4b0e-a8d3-bfed564f5bbf?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.27632.13665499948454255.6c2e1d5c-1a06-4839-a773-4e814ef1ff4b.5aa64aae-6a76-4d9c-ab2c-317138c01c78?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/yakuza-5-remastered/9NK23S9XBMZ6"
     },
@@ -6626,11 +6618,11 @@
         "releaseDate": "24/03/2021",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/yakuza-6-the-song-of-life/9NK3ZFC5R579",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.35958.13668783294084992.4ad59615-2917-47b4-88c2-a829ef88fc9d.d54cbf99-5857-4a78-815d-d7f680d55edb?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.35958.13668783294084992.4ad59615-2917-47b4-88c2-a829ef88fc9d.d54cbf99-5857-4a78-815d-d7f680d55edb?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.22032.13668783294084992.4ad59615-2917-47b4-88c2-a829ef88fc9d.9b4b924a-aab0-4075-8068-953ee5f06891?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/yakuza-6-the-song-of-life/9NK3ZFC5R579"
     },
@@ -6644,11 +6636,11 @@
         "releaseDate": "21/04/2020",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/yakuza-kiwami/9NBJ51BD0LTH",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.3710.13512592555926242.4f764cb5-1ca8-4601-9f0f-fd3d82976ea7.ffff5017-617d-4238-afc5-59551b5b4f47?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.3710.13512592555926242.4f764cb5-1ca8-4601-9f0f-fd3d82976ea7.ffff5017-617d-4238-afc5-59551b5b4f47?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.8346.13512592555926242.4f764cb5-1ca8-4601-9f0f-fd3d82976ea7.dee63792-f454-4a83-b3a2-3e8ddf982573?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/yakuza-kiwami/9NBJ51BD0LTH"
     },
@@ -6662,11 +6654,11 @@
         "releaseDate": "28/07/2020",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/yakuza-kiwami-2/9PBJL0NLFMK9",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.62149.14117812508694764.cd76a3cb-9c02-4790-93a0-eae298c80bb7.55a328e1-e09a-4431-888b-f4c6989f5683?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.62149.14117812508694764.cd76a3cb-9c02-4790-93a0-eae298c80bb7.55a328e1-e09a-4431-888b-f4c6989f5683?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.20980.14117812508694764.cd76a3cb-9c02-4790-93a0-eae298c80bb7.1d5a6e2b-f1c7-4e01-aa1d-700cb5bb99e4?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/yakuza-kiwami-2/9PBJL0NLFMK9"
     },
@@ -6680,11 +6672,11 @@
         "releaseDate": "09/11/2020",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/yakuza-like-a-dragon/9NXCSWCQTNFG",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.30664.14427542363794747.182f58ca-3a24-4a65-93bd-cdd320a35776.d7799370-aefe-44e7-8f83-4f8a5c363354?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.30664.14427542363794747.182f58ca-3a24-4a65-93bd-cdd320a35776.d7799370-aefe-44e7-8f83-4f8a5c363354?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.29145.14427542363794747.182f58ca-3a24-4a65-93bd-cdd320a35776.d3800c18-f897-458a-8b39-a337fb55f00d?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/yakuza-like-a-dragon/9NXCSWCQTNFG"
     },
@@ -6698,12 +6690,12 @@
         "releaseDate": "14/09/2022",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/you-suck-at-parking/9NCF3MRQ8480",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.25613.13565037407534311.ea0dd485-42ff-445f-ad44-0867748af14c.20d3b6e3-28d3-4875-b8a8-2c6def19eab4?w=%i&h=%i",
-        "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.603.13565037407534311.0d8dd6b7-ba76-442e-8a83-5547f7a8f00d.efcbe208-cbeb-4a99-9f3b-1b547a328e48?h=%i&format=jpg",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.14803.13565037407534311.79e1eb9c-1c47-4537-8019-ee8d89c59961.795a97b3-620d-417e-9405-9302687de1d5?w=%i&format=jpg",
+        "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.53715.13565037407534311.79e1eb9c-1c47-4537-8019-ee8d89c59961.661ee2cb-0b87-43c6-8aab-ec22b10b1ca4?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/you-suck-at-parking/9NCF3MRQ8480"
     },
     {
@@ -6717,11 +6709,11 @@
         "releaseDate": "10/03/2022",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/young-souls/9PMM5T8C0CN6",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.56680.14291150913821725.3d8057b5-357a-4911-a453-96660fa5c913.b9598d6a-327c-4ea7-b1bc-e3886f94dfe8?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.56680.14291150913821725.3d8057b5-357a-4911-a453-96660fa5c913.b9598d6a-327c-4ea7-b1bc-e3886f94dfe8?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.8536.14291150913821725.c366710a-83fb-4fca-8c0d-4e933afd9a48.4fb69450-8bd0-4c59-91e0-cc68747a2565?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/young-souls/9PMM5T8C0CN6"
     },
@@ -6735,11 +6727,11 @@
         "releaseDate": "21/03/2022",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/zero-escape-the-nonary-games/9P47H1RVDWWW",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.5566.14594067352473910.0b999f06-79de-4e28-92ef-eabddfb67749.354a1ba9-4163-4e87-8dbb-d2e6181a67ae?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.5566.14594067352473910.0b999f06-79de-4e28-92ef-eabddfb67749.354a1ba9-4163-4e87-8dbb-d2e6181a67ae?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.35064.14594067352473910.0b999f06-79de-4e28-92ef-eabddfb67749.12b0713b-54c9-4f99-8e37-39e252c8b8c0?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/zero-escape-the-nonary-games/9P47H1RVDWWW"
     },
@@ -6754,32 +6746,13 @@
         "releaseDate": "03/02/2020",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/zombie-army-4-dead-war/9PLSCHRN5715",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.15083.14307155302772688.6d2bb19d-e8cc-4826-bd21-920020654895.22cfc234-258a-4edf-b871-db3c9e4a7127?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.15083.14307155302772688.6d2bb19d-e8cc-4826-bd21-920020654895.22cfc234-258a-4edf-b871-db3c9e4a7127?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.2216.14307155302772688.6d2bb19d-e8cc-4826-bd21-920020654895.bdcdac0b-51a7-48f8-815b-e77215cd2c8e?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/zombie-army-4-dead-war/9PLSCHRN5715"
-    },
-    {
-        "gameTitle": "art of rally",
-        "gamePublisher": "Funselektor Labs Inc.",
-        "gameDeveloper": "Funselektor Labs Inc.",
-        "gameGenres": [
-            "Corrida e voo",
-            "Simula\u00e7\u00e3o"
-        ],
-        "releaseDate": "11/08/2021",
-        "extraGameProperties": {
-            "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
-        },
-        "xcloudUrl": "https://www.xbox.com/%s/play/games/art-of-rally/9P6JQDDZ2MQB",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.12769.14623403501904333.a0e82bb4-85b9-4a3c-9fd8-d7d04e850bd6.6db97f4e-c835-477c-8a83-06ccd306bd73?w=%i&h=%i",
-        "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.46481.14623403501904333.a0e82bb4-85b9-4a3c-9fd8-d7d04e850bd6.dc3977f6-caa0-48c0-9f1d-1d925af2accb?h=%i&format=jpg",
-        "storeUrl": "https://www.xbox.com/games/store/art-of-rally/9P6JQDDZ2MQB"
     },
     {
         "gameTitle": "skate. (2007)",
@@ -6791,11 +6764,11 @@
         "releaseDate": "31/01/2011",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
+            "controllerSupport": true,
+            "touchControllerSupport": true
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/skate.-2007/C3QWNCV55VLL",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.56436.66765638016841945.44eb6927-d62a-4346-a97d-4d1d0881b107.ac9661f7-1e16-4df1-bf81-119631e97f8b?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.56436.66765638016841945.44eb6927-d62a-4346-a97d-4d1d0881b107.ac9661f7-1e16-4df1-bf81-119631e97f8b?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.27751.66765638016841945.44eb6927-d62a-4346-a97d-4d1d0881b107.1d18ea8a-3fb7-4968-b240-411a3fc2fd37?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/skate.-2007/C3QWNCV55VLL"
     },
@@ -6810,11 +6783,11 @@
         "releaseDate": "01/10/2017",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
         "xcloudUrl": "https://www.xbox.com/%s/play/games/thehunter-call-of-the-wild/BXBJQ1932138",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.9956.63553167684393025.1b31f51e-c4c6-49b1-bf61-a2e65ea14c73.a126b6d1-284c-4746-a11d-f6af188d1918?w=%i&h=%i",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.9956.63553167684393025.1b31f51e-c4c6-49b1-bf61-a2e65ea14c73.a126b6d1-284c-4746-a11d-f6af188d1918?w=%i&format=jpg",
         "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.48448.63553167684393025.1b31f51e-c4c6-49b1-bf61-a2e65ea14c73.829114dc-cfe8-49ab-8636-0440de686f23?h=%i&format=jpg",
         "storeUrl": "https://www.xbox.com/games/store/thehunter-call-of-the-wild/BXBJQ1932138"
     }

--- a/tools/xcloud_recents.json
+++ b/tools/xcloud_recents.json
@@ -1,286 +1,279 @@
 [
     {
-        "gameTitle": "A Plague Tale: Requiem",
-        "gamePublisher": "Focus Entertainment",
-        "gameDeveloper": "Asobo Studio",
+        "gameTitle": "Battlefield\u2122 2042 (Xbox Series X|S)",
+        "gamePublisher": "Electronic Arts",
+        "gameDeveloper": "DICE",
+        "gameGenres": [
+            "Jogos de tiros"
+        ],
+        "releaseDate": "01/06/2021",
+        "extraGameProperties": {
+            "isInGamePass": true,
+            "controllerSupport": true,
+            "touchControllerSupport": false
+        },
+        "xcloudUrl": "https://www.xbox.com/%s/play/games/battlefield-2042-xbox-series-x%7Cs/9P0T51BDDWVT",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.64912.14524595367279766.5574916c-be72-4bad-ab36-3d4205eb1ab8.3b64ab3a-93aa-40c0-bbdb-ac8057860c3b?w=%i&format=jpg",
+        "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.17097.14524595367279766.5574916c-be72-4bad-ab36-3d4205eb1ab8.1846326a-6469-4198-afd0-d54839d905e5?h=%i&format=jpg",
+        "storeUrl": "https://www.xbox.com/games/store/battlefield-2042-xbox-series-x%7Cs/9P0T51BDDWVT"
+    },
+    {
+        "gameTitle": "Chained Echoes",
+        "gamePublisher": "Deck13 Spotlight",
+        "gameDeveloper": "Matthias Linda",
+        "gameGenres": [
+            "RPG",
+            "A\u00e7\u00e3o e aventura"
+        ],
+        "releaseDate": "07/12/2022",
+        "extraGameProperties": {
+            "isInGamePass": true,
+            "controllerSupport": true,
+            "touchControllerSupport": false
+        },
+        "xcloudUrl": "https://www.xbox.com/%s/play/games/chained-echoes/9N1WWRPJ12FK",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.48881.13967692908687056.7893a3a8-746a-4e4f-aec4-16ec6b5ba396.ad337e09-7f04-45a9-b86b-eae8cc8c5067?w=%i&format=jpg",
+        "gameImageUrl": "https:AAAAIGZ0eXBhdmlmAAAAAGF2aWZtaWYxbWlhZk1BMUIAAADybWV0YQAAAAAAAAAoaGRscgAAAAAAAAAAcGljdAAAAAAAAAAAAAAAAGxpYmF2aWYAAAAADnBpdG0AAAAAAAEAAAAeaWxvYwAAAABEAAABAAEAAAABAAABGgAAEvMAAAAoaWluZgAAAAAAAQAAABppbmZlAgAAAAABAABhdjAxQ29sb3IAAAAAamlwcnAAAABLaXBjbwAAABRpc3BlAAAAAAAAA8AAAAIcAAAAEHBpeGkAAAAAAwgICAAAAAxhdjFDgQQMAAAAABNjb2xybmNseAABAAEAAYAAAAAXaXBtYQAAAAAAAAABAAEEAQKDBAAAEvttZGF0EgAKChkme/hvogICAwgy4iUQ3ADDDDEAgkD0uJloL/IWGSkZEGwVSjLSqtILBrBvhRKu/6G75+rbd8CBGI6qRciStZmCl66cJxpKxnVsXUEnyN2OBSyFEgAn/xbYB63xcP1qMhb4z6vBJAzl22YDQxowxfnTTsJvEc7jHtpQtRO8zXIkxH5FOSkKZgnLoocuWmsyLCeBMQ/Y2CfCcXFBGLAL5Od9gZwYKKyLD2DkdggKfyFlsS9eYivYaecJ6dPwWnfq/jtOpSva5kgf4m90Tbk18tvO36SZdWw9bcVSYZMbXpUICh1L8i4ikoY8o4EBlbTnA+dBj1gKRSm+ydBSv30aoFTZDhrS879mxefVyRJgymecRhfHObIgpnhmmih/EVR6b3ywnBHOPzV9DG7idFy3f3ev01QzSIiAoMO7sX+R9juuNPuo/T3GmNt5vXMctoZgStYZ6N8M/hqa7OFLHMSPVc0KsW88yMb9lCFAdl3dus/YG5dpyV356GImj5iuvb0AdBMG1KNqHSLTMlSb6W9jpbIimiNTSAr3A03SPa3tV0YoqN72wMto6z33nyD9Rxtjr+eV+xarO+0XzL6gGhvxYWvOOCnEIkEuF1LFQsqbFhxel2CXIGQJ685Y94pmXVjFIeAk9m7UlYRN4YsvYEqh3atflxyBVYG3LLJejL/l/2rIsSe1qtP3AQfAFbGjVSt42P6iQhIEM9Ft7Yl0vnW65zsbZcOILNQ93ecTby3bvvN00klgQqfiMajeH/Us5xuX+Fz+AAAXqja8OB1suZ3rnbL+Y6HRCga4bfyfZMnaCOp/FvrENDdWqciuBX2htYA+0wjgksZ9wQm9VdoPrN80Mw1PIlz0Z/zcqgSW2pH3pLUI7ZuoFvhNP3WEAw1csgbk0hmeAp4PLUNhz/M3/y0mWYF1I1y1grofKEHSZwxPg1wcB/kI/kVBt5OMrGlfcbmHogib+dQHwch/Lnzc1Uto4Kh3Kukat+ArF8vAnP2EO5Ko2jQYnC6/b/W00k9DogEiJQKBsv410VrDAiW/lCBAvqwJMD+f9PZcxc0/zrirz/5O+I2iREATjE1TD68QWnha05B1w+dWFkPplo5UcuKkTySgri3pdDmIbasDt3nYFiD58zL8O3/2TmbULUf+DfPNkBzGtUFbaL206BI0SyiiEcDLqMxY3GCBvl5jrPID6ctR9H/8xhRZ+p3sA2UgsQCYL7O/dxR57FIerX3l7QOpmkkVZLkc8Zq3bHCHrO2g+P8SV0gpdZNR7Jt6dUSPZQXsIWXInEwtha+SizSJRFIT82YJMwhQRM7RtrfjwwNt/disBRQZ4Fgt3yvbVf/gOXE9+a2Oj5UV/fs9/6R/sWA8ulTq2iPfuXWnVoYq8bmaeRgRg2mWOeotIxjl5Nvz7vbNjRwy2JGhwr7Tw4yf6A5UNNv1ODQXA4Lq92+fQ83EWPubkOw+ZsBN18Iw5Nawbgm0LmT0YByqkqSQQABykNU1MSqYcoGSGGi720FvEHyUinYPhlsmkef0Emj1kK7R08HmEflnpIGV/eMYgYnrxeA68qGGAU1VHWCsDd7nKAolXlOJJDecwr75P2AoaXRdIGJj9bCpFDjMIA69rlnBhsVoO3DQcA5EgwjMJiehDEJIi5ZDW4BKrPiVZhbEOKBFi9j1lHT0Q02NSsgoOcY6DUkkvCys7hvEWLHK603KbJgvLIix6SeTc3Z85diDrzyOPoB3FpwWrGwDYI6qtXMUMoWGHiqF8ndKfRMxapILkDKEwEl1TcLY9uYPTx7MBB1cYJEO26/TEyQrDom/t9AxzbvchhHn/s4cT6NIWKye5/Ax3/lQprrRSKHHhUXgZDHU8b55cGJvIOaPAAVU/OWSXvFJaJg7NAF59KLTs/QaQOY+XOkOrVckngjWfqptMTt7F14By9thqXTzB2yJw+26DbaRf8Q/AObcca5Bujoh9YH1SL3BlPElHhONTN78REUNH4JqSibgmMAaxDCTxjLLPOydVstEunniC6kySY6sZxtig3L885KY7seoxlxXtMEmvXSSaJfiV/r6Cgfe7IfRtWAxdpaCi3VGllDHD9H0b5VHvk3QfeTlXyzoXRoecZmoC/GmCplwCFBjViOuEVsacMcqtJYcF57qAAYOYSrXXKvRkG6mwvF1QbaLRHLANnBJ/OSFVOt93MNLafQ11pJEa2qfoSm71MOy7lpMgLQ5Qqf/DA9I16DUQVxqEAsu48k4kKxrsIHMObWEQmWX4wrk44aebulLGATBlxMMBKF1kkv3pd68mZcRezooop+fh7/9LPbUurm7s8dxk8kpvYqFUkIpF8sLiOnmyEB/NyBlurTgV/yQD+zA0BLm4nO6QHxWDrfV41ZQAYghz/AXP9ikxlvHM6Xv/LMjKc1isyxMTLSRwIa2IoxCaFv6eWsnxFFpFSAejBD4t16+EJuQchYOrQ6Vt/n/al/Z/onRaZ+e1/SSYCegCrlMzjpolzqZrCjX3vaGI+RuQ7f8u0Gnp8ij6KNnPPWJA0gPv5fSUav+D8Rhb4zPmIfYcmvr8z0apIXbNA9cO47fJNYJ6CqHXTukpV4YarR9Q48tUPUKbi5q1fuEE9gKSRXa3GW4sd9EiLsOST/CsR10ouAUXVmcao8FNXgzNw3fCpvdk4EwNbsAY4po7KSRNV57rVAqY6Q/2xPRI9uvqFIEQuepUwAQoQH98uNlXz6ZO9OnKc/GZSoKs94LN8IuyPMTrDjoILvBeH8Ob9B3BNq4OwgLDL4hKq4zwIQMVms4CJDk311zy37RkS5fxDLddfw1A0s1fOsVwr63QeyllZpq8vTWZZWZBNICezB1+v4QiS4KHaJJyHlnbVeJB1WrUmqvSYKMm3SV2c2XtQoNW5A4ccQI3LqT5v9I/Z3ATGDMov35j95IxCx9ArKxYPt+JlHxesbpLXYXijz8XlVmoBlI+veHUAX+qhPX2ktDz+yabpDom/avarmkPt3ve2es+zyA9MfMZd7nIximUgqZNEBoKhtq56jAzx5iwblt1AXVaME1qdSgrFNREt+7TRInJ7VkzYeSDiH6i0dKe+tTgxejF6CZE5IU8KYYZABhY3kC/oaybwH1+ahxKLz3+FDUZH/XP2vjY8DIhq4dVuBJpHvadH2mE7nrVHsITPfdqtqpBd6fFPRqXlW+QuD0lRCa8ocnNqpdhSIqoC9SqdrwLtQIqAbj7AYNVhNp9HnJd5BSBdSskuCG/SBGVLeh+Mbb05+E9oU0VQb2DJNKUm5wsW/wR9B/JNSVej5stWVqomlHN+ZG7oL4kKM1ftyDqY/5/NoeDgpFSwyqsa1/M+IVnlK/jFmnBA0wxz5phnzmsCvFwO69Yw3o11fEw4/59zhO75WYX7AMrq3XGt8RL/kAKJzfChOYnxmJpe2YOKiU/MbxhKFxnqt4/aA8nGjOz80PBaFx1B/BqBriBmg1Cdvdtt668/GQufmcALI5esAobu0QPFaT9mWtbYUlxPfp1vP9XraiyWL2OQ897rcjBBBgDo6iw5NJjFF+kzx9UvZEzNF1ZEvYaksTNzP94HXgx6IukDGf5MKwUsubgmn0ozatMNqi1ECQnsf1xkmnTT/wa0i48JJeCf1QBps2b88aw4ZMwq8OEbFqngpuqq/cUvQkP8mX84ABfcoEWjDdPaKkrEquOXbDf/7wddVo7JgKZvcdXFhtmp5mSLXUal9hTDVvcpFjxL111GCryDjLkzajV3N0mO5T1feP1XPIPeIbvX/Dm4LSSEhBgq8WcmviCbHhkVZcYZAR0DeCfaGH4gkTKS3u2tGZWEFVMQDhqm/fZRNroLa7mrd62bJkZnyMUwsDOxUnCu0H0pA3DgQLsj79aYMgzBDGbJIIHl79PFzRULrJWaUP7Hr2LRBCgXXVNY7/q+kZ5/4uh+epdFlaeQk1bewxjJjVFLNYGYJV6u+wb8wHLjIdykYIiRWrgvy45GK0iOGVD7aCHVc1rlLTrrrUF8qFclPi1liqnTRhRs8fC87i+tjteCSlOH1hijdkyFyEg9QY7wedQ8cnz1hAa47MLpDBH/418seOjYm2NJ6HQSu4PA1uggd3OXMRp2nAMvxGwnTWFZ1yoauZeUKwlu8UoOOwzzJK+9RcjhcN1cTo8vjq73jW0y9aJKSnmT2lQ8HtR0rKJovkgOkHS3uM25OTTxX5owx32w8N+rZnjaCIiOqrPRr95v2BW/0FTgjZjAklwz9vycjH4d/GeKW0HOthccqLQsFoUUFOpwrRcXElWOnzRm+4N+XmbSZe+XtQ23W7ywh6uER+nWl9/24Fc0bPSNaraju7EJR9Ro8E0QPcq2M9vPOECihAVI8T12a4T92OpPk0F7jq749ITIEWqxZdHiJGwkkKI86TNGag5tlT23B6YRyCMUNeShBT0hYUkOrxTTxXrMI+gtNfWTKTxc7oUDATM/E4qE8MgqFOkaCc+oEPXaheSjXKes+31+pe9Hda3u2ORvx5vM9Ds0CMd7cCl1QsyeORBAgheisWLkPtGdowkL2KsX42BH7sCb4a6x/RtJHAY581BcUJrbeBq7o7I+YVpIcQtP004H06AqLmCedddfHcySVl5FAUtxLRszgJJjuL9hxLZvKPTjL3db5PuFJYG+oI0t9IqBBd3AtCX00xiqtWEajQE548rm5MLFR9dwGAEjRGmyBVnOZDBId1TiLyymuqCrilcYJ3bz7xGR8HGgxVrRiT44NNGIprOkQv9kb3Fy8ZllXFMa8h7rFC3qVg2M3p6mVCOMGNVBML5kyXyLQ7CNbgQDVc9ep49XcP+Ij2uKORHUZ3SfDJZd57oR0NNwA5nzNOLOc+wlwYAaRSOHKIKh9UM5RdqZy5lU2kNWOwfovvoReYNWm6P80s3/r8PQ/n3MutbsEGJ2mWBSslGdo+JH6pYd2hg/rlISngXndT0GwzocFRcmjddpXY67OV0sUaTepGzWr3ntujW0/IJRC1Zej0SXDaiR+e9VyE7rgTuoU2gEiU0N5Lqbr5tZuqx8TGXs3cQLyZpC6wH+LdyTF4J0fmDlIBphe7r5IDCRBG8eOXuZRXGSoGPYaOmA2PUJefh7fVflc0LG36i5MQmF/KI7fTxavg+8/kH4gIh3S40X5V0sPxsNKPfNKJwKE2RPVXIqHzzWyPqEqwAI8PZZb1RrnI9nzlDH5UF3tIH4Cibmn0iifDFXW96ZT5fE57MAXFk90gfVIGCfg4AuR4aM5j0gr/LCPd3N6BDUGN1NelVsHfjf3J+sdlBhSHN31bcMDLqLXz8dGrKRAK/MWOhF2OhmanABLLp6+pDkzNItsgH08ZyyictMPUQuHIG+bBQlF53b0fbgQIZ5Q4O72zfCMDEz55qAIvc0NBuJIZumsUxUe7Dk0LLqjzZdfMivzdNmBJpATZOf72RZOHaUHehpecqOLXIk83Vsn0u77qIiJDsIXz45stg1ApnELGWM0VEJvaK1cD2WSJ2n8U/Phe9ynHcCNTjeSblB41b5icDZw0TNmU3QKtNovfZ8UUwgMNsbgxh+UCxhDYwfn3tfMk+iRRHn9pCougsMx/+0ungeJkxnZD5Z1Ux9G1vuTO6b0AeFnuNUoLpuo2K+Zu9RkI1rBfFFosSzJkk/G3REuZHMPQ5/WghwR0T848P3BbNsEJQWXao/PdtGXVN1OTuauMJVZFwSX98ndPmSQIbnB/ATIeKecx0+HLq7uxCzEFkmD3Cc+g4+jYg9YwBCyveCxRcOeDh5Xk5S18jBMbM2oDvLR9pKgEo1kaG4FJeH9vIVQbniQcqemdr86ZG8MzXlyZjfU8+rFrYToSRpCxV217GlWcf1tJEicM9IoMr2OxW254PlBgMfrHJc89wfmzHhs5+Bs82zEl8OiwGTh0GgxCDrhZ/z6RRywPG2aG4BcsGo6RGrp0ggzt8UtJSfvtpWcIq8iiKVcwTRzBW/UB534GohOljBPEQ+3z5sR7CpyW/aUCTbLtvBgg32osefXBOh9+KVhJI4dSM5OqIie2ohUk1l9wFEE3csezdgrydGTzeejGTbARd0Vlg8+5aa8Pjp52qR3SAtKrMYhV4pnRVKQNj5Q+cG9SCQ9mgSEjSHIVn7QAEFsnqvuMcEbfq/kcuT/zW7TLvJ4ttp8VsABhQBIss2uO2Sr8uzBnfcVGSvQJOux2uKF+tESgB9uFNQ6dNnr4UXGAa/FVoA+BWavJEsUOtafDzsuvypNyhqsN2xdaGxSYF8W/oI9AWcfrT8uxEoKGRWG+A8OkI2e0eq5RAudLh6rrlLh780d8TxP58UhGod6pOBKroGpmVj3ST9geZ67UfueS+bLv/Pu5Fhpv2/F4F3ZSzgJxIFnMZhuqmzEpCo0ezxMEQfO0TQuvQijElCxc9l0dJz1hAqslxGSKpjS7JnoGha7MHEvczLnl0d4hu+6gN2eIC8nGKS0oV8u5x/oZP6QpriEmZfPI9am/mQ2%iB",
+        "storeUrl": "https://www.xbox.com/games/store/chained-echoes/9N1WWRPJ12FK"
+    },
+    {
+        "gameTitle": "Eastward",
+        "gamePublisher": "Chucklefish",
+        "gameDeveloper": "Pixpil",
         "gameGenres": [
             "A\u00e7\u00e3o e aventura",
             "RPG"
         ],
-        "releaseDate": "18/10/2022",
+        "releaseDate": "01/12/2022",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
-        "xcloudUrl": "https://www.xbox.com/%s/play/games/a-plague-tale-requiem/9ND0JVB184XL",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.60562.13558336166432541.beb57fbe-cc4b-40c5-ba76-c8112867dea2.9a69e497-4f9f-495d-9ac6-f8956b491d91?w=%i&h=%i",
-        "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.59830.13558336166432541.beb57fbe-cc4b-40c5-ba76-c8112867dea2.f764a45c-f860-483f-b264-aa9041f2bb62?h=%i&format=jpg",
-        "storeUrl": "https://www.xbox.com/games/store/a-plague-tale-requiem/9ND0JVB184XL"
+        "xcloudUrl": "https://www.xbox.com/%s/play/games/eastward/9NSBX56ZNP7X",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.35706.14370759136672533.dd01dbaf-ca58-4330-83f4-614a98d999d1.3ef6b81b-a103-40d7-b005-269e2785956f?w=%i&format=jpg",
+        "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.16050.14370759136672533.dd01dbaf-ca58-4330-83f4-614a98d999d1.8910e0af-a260-434d-8ebd-3d61c602a123?h=%i&format=jpg",
+        "storeUrl": "https://www.xbox.com/games/store/eastward/9NSBX56ZNP7X"
     },
     {
-        "gameTitle": "Beacon Pines",
-        "gamePublisher": "Fellow Traveller",
-        "gameDeveloper": "Hiding Spot",
-        "gameGenres": [
-            "A\u00e7\u00e3o e aventura",
-            "Fam\u00edlia e crian\u00e7as"
-        ],
-        "releaseDate": "22/09/2022",
-        "extraGameProperties": {
-            "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
-        },
-        "xcloudUrl": "https://www.xbox.com/%s/play/games/beacon-pines/9P4R2M0NRWNK",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.23560.14588206397851258.078192f2-519f-4a81-b68d-2dbd6199f2c2.af953250-54af-4a2a-be0c-163b68917421?w=%i&h=%i",
-        "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.39650.14588206397851258.078192f2-519f-4a81-b68d-2dbd6199f2c2.0f659ae9-51f1-4a1d-a086-0a5f165d5b5f?h=%i&format=jpg",
-        "storeUrl": "https://www.xbox.com/games/store/beacon-pines/9P4R2M0NRWNK"
-    },
-    {
-        "gameTitle": "Chivalry 2",
-        "gamePublisher": "Tripwire Interactive LLC",
-        "gameDeveloper": "Torn Banner Studios",
+        "gameTitle": "Gungrave G.O.R.E",
+        "gamePublisher": "Prime Matter",
+        "gameDeveloper": "Iggymob",
         "gameGenres": [
             "A\u00e7\u00e3o e aventura",
             "Luta"
         ],
-        "releaseDate": "08/06/2021",
+        "releaseDate": "22/11/2022",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
-        "xcloudUrl": "https://www.xbox.com/%s/play/games/chivalry-2/9N7CJX93ZGWN",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.61947.14071745200459129.81e3e86f-3ab4-4027-b9a1-81f595fcb505.fc2487e4-7785-4a73-b2ad-b94aa01a7e7f?w=%i&h=%i",
-        "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.56595.14071745200459129.81e3e86f-3ab4-4027-b9a1-81f595fcb505.bcc44c15-cee0-4c07-a92c-766beb8fb174?h=%i&format=jpg",
-        "storeUrl": "https://www.xbox.com/games/store/chivalry-2/9N7CJX93ZGWN"
+        "xcloudUrl": "https://www.xbox.com/%s/play/games/gungrave-g.o.r.e/9P87CLMPXSN6",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.33649.14093130471487401.df18e01c-f89f-4906-966f-7d30cb5f9f10.ba37ac7d-b4a9-41fc-bc34-55367d2a5348?w=%i&format=jpg",
+        "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.60952.14093130471487401.df18e01c-f89f-4906-966f-7d30cb5f9f10.91c991bd-7e68-4874-a3ed-4c4edb6a0422?h=%i&format=jpg",
+        "storeUrl": "https://www.xbox.com/games/store/gungrave-g.o.r.e/9P87CLMPXSN6"
     },
     {
-        "gameTitle": "Costume Quest",
-        "gamePublisher": "THQ, Inc.",
-        "gameDeveloper": "Double Fine Productions, Inc.",
-        "gameGenres": [
-            "A\u00e7\u00e3o e aventura",
-            "RPG"
-        ],
-        "releaseDate": "19/10/2010",
-        "extraGameProperties": {
-            "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
-        },
-        "xcloudUrl": "https://www.xbox.com/%s/play/games/costume-quest/BR74RLMH966K",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.18636.69532389726997442.230b98e2-1f17-47ab-9d5a-06afb771f0de.57d2c274-ba74-4d0a-a98f-24a4ca808a82?w=%i&h=%i",
-        "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.47121.69532389726997442.230b98e2-1f17-47ab-9d5a-06afb771f0de.a4b185ec-6d05-4391-9919-046299c7651b?h=%i&format=jpg",
-        "storeUrl": "https://www.xbox.com/games/store/costume-quest/BR74RLMH966K"
-    },
-    {
-        "gameTitle": "DEATHLOOP",
-        "gamePublisher": "Bethesda Softworks",
-        "gameDeveloper": "Arkane Studios",
-        "gameGenres": [
-            "A\u00e7\u00e3o e aventura",
-            "Jogos de tiros"
-        ],
-        "releaseDate": "20/09/2022",
-        "extraGameProperties": {
-            "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
-        },
-        "xcloudUrl": "https://www.xbox.com/%s/play/games/deathloop/9P5Z4530318L",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.5858.14634955238674857.649b7ff9-0dfc-4951-9b65-c5d815215da6.90208516-ba3b-47a9-a130-ef94cf860f5b?w=%i&h=%i",
-        "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.26641.14634955238674857.649b7ff9-0dfc-4951-9b65-c5d815215da6.bacdd878-0313-4c58-9434-459afd7cf535?h=%i&format=jpg",
-        "storeUrl": "https://www.xbox.com/games/store/deathloop/9P5Z4530318L"
-    },
-    {
-        "gameTitle": "Despot's Game",
+        "gameTitle": "Hello Neighbor 2",
         "gamePublisher": "tinyBuild",
-        "gameDeveloper": "Konfa Games",
+        "gameDeveloper": "tinyBuild",
+        "gameGenres": [
+            "A\u00e7\u00e3o e aventura",
+            "Fam\u00edlia e crian\u00e7as"
+        ],
+        "releaseDate": "06/12/2022",
+        "extraGameProperties": {
+            "isInGamePass": true,
+            "controllerSupport": true,
+            "touchControllerSupport": true
+        },
+        "xcloudUrl": "https://www.xbox.com/%s/play/games/hello-neighbor-2/9N961B11FJ4W",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.33283.13538643730533052.28638370-579e-40f3-af52-7a9f26631587.11c36bdc-b917-4415-a3c1-5de382376d4a?w=%i&format=jpg",
+        "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.9994.13538643730533052.28638370-579e-40f3-af52-7a9f26631587.2e51d281-2762-496f-8897-1abdd3ade005?h=%i&format=jpg",
+        "storeUrl": "https://www.xbox.com/games/store/hello-neighbor-2/9N961B11FJ4W"
+    },
+    {
+        "gameTitle": "High On Life",
+        "gamePublisher": "Squanch Games, Inc.",
+        "gameDeveloper": "Squanch Games, Inc.",
         "gameGenres": [
             "A\u00e7\u00e3o e aventura",
             "Outros"
         ],
-        "releaseDate": "29/09/2022",
+        "releaseDate": "12/12/2022",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
-        "xcloudUrl": "https://www.xbox.com/%s/play/games/despot's-game/9P5ZDVMCJMFD",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.54530.14634731171917513.ee44ea98-341d-42e8-b67a-c2a4254a08a0.3a8876e7-694c-40d5-8efc-0264051414e8?w=%i&h=%i",
-        "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.13399.14634731171917513.ee44ea98-341d-42e8-b67a-c2a4254a08a0.4239454b-8c5a-4424-b410-2039ca63a84c?h=%i&format=jpg",
-        "storeUrl": "https://www.xbox.com/games/store/despot's-game/9P5ZDVMCJMFD"
+        "xcloudUrl": "https://www.xbox.com/%s/play/games/high-on-life/9NL4714VTLRS",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.45698.13714596773589453.b0e22fc5-f8b4-4b36-b12d-db5d42554c10.bc780adb-55cc-425c-9e65-e86696d7d030?w=%i&format=jpg",
+        "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.37926.13714596773589453.b0e22fc5-f8b4-4b36-b12d-db5d42554c10.3e5bce4c-674d-4a02-82f0-67bec617750d?h=%i&format=jpg",
+        "storeUrl": "https://www.xbox.com/games/store/high-on-life/9NL4714VTLRS"
     },
     {
-        "gameTitle": "Eville",
-        "gamePublisher": "Versus Evil, LLC.",
-        "gameDeveloper": "VestGames",
-        "gameGenres": [
-            "Outros",
-            "RPG"
-        ],
-        "releaseDate": "11/10/2022",
+        "gameTitle": "",
+        "gamePublisher": "",
+        "gameDeveloper": "",
+        "gameGenres": [],
+        "releaseDate": "",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
-        "xcloudUrl": "https://www.xbox.com/%s/play/games/eville/9PC12991NZ5N",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.31296.14112988465880137.944f8dc0-63f1-4f15-96aa-cab88a628053.65e7f8f4-3625-4a09-8aa7-fead27a7806f?w=%i&h=%i",
-        "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.19828.14112988465880137.944f8dc0-63f1-4f15-96aa-cab88a628053.3baaa95c-7788-4c73-aef5-b1cd1bd840b6?h=%i&format=jpg",
-        "storeUrl": "https://www.xbox.com/games/store/eville/9PC12991NZ5N"
+        "xcloudUrl": "https://www.xbox.com/%s/play/games/insurgency-sandstorm/C46KTZB9HK8B",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.28821.66496411985646769.c617342d-28e4-4aaf-9b96-89dda9e9d20e.82d12f06-0792-41ee-9436-fa92b1f55f06?w=%i&format=jpg",
+        "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.6975.66496411985646769.c617342d-28e4-4aaf-9b96-89dda9e9d20e.13a82ad7-4c91-4952-aa81-91d965cdabeb?h=%i&format=jpg",
+        "storeUrl": "https://www.xbox.com/games/store/insurgency-sandstorm/C46KTZB9HK8B"
     },
     {
-        "gameTitle": "Grounded",
-        "gamePublisher": "Xbox Game Studios",
-        "gameDeveloper": "Obsidian Entertainment",
-        "gameGenres": [
-            "A\u00e7\u00e3o e aventura",
-            "RPG"
-        ],
-        "releaseDate": "27/09/2022",
-        "extraGameProperties": {
-            "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
-        },
-        "xcloudUrl": "https://www.xbox.com/%s/play/games/grounded/9PJTHRNVH62H",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.36912.14280109286674604.94f3a3e8-211f-41e5-ac9c-d948b5377852.4e9bf257-12e0-4f04-9239-671818df45b0?w=%i&h=%i",
-        "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.27514.14280109286674604.1fb359e4-01eb-4818-b992-b225ce4869c9.c9733025-0344-4e66-aff1-ee3bcf9016a7?h=%i&format=jpg",
-        "storeUrl": "https://www.xbox.com/games/store/grounded/9PJTHRNVH62H"
-    },
-    {
-        "gameTitle": "Hardspace: Shipbreaker",
-        "gamePublisher": "Focus Entertainment",
-        "gameDeveloper": "Blackbird Interactive",
-        "gameGenres": [
-            "A\u00e7\u00e3o e aventura",
-            "Simula\u00e7\u00e3o"
-        ],
-        "releaseDate": "20/09/2022",
-        "extraGameProperties": {
-            "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
-        },
-        "xcloudUrl": "https://www.xbox.com/%s/play/games/hardspace-shipbreaker/9ND8C4314ZZG",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.11359.13552902647075103.9e24872e-3f43-4078-8279-1ddf37a77ab1.795f17b4-3acd-4226-91d9-5c6031d7899e?w=%i&h=%i",
-        "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.36125.13552902647075103.9e24872e-3f43-4078-8279-1ddf37a77ab1.246fb260-7ac0-4916-867b-dce60a943024?h=%i&format=jpg",
-        "storeUrl": "https://www.xbox.com/games/store/hardspace-shipbreaker/9ND8C4314ZZG"
-    },
-    {
-        "gameTitle": "Let's Build a Zoo",
-        "gamePublisher": "No More Robots",
-        "gameDeveloper": "Springloaded",
-        "gameGenres": [
-            "Simula\u00e7\u00e3o",
-            "Estrat\u00e9gia"
-        ],
-        "releaseDate": "28/09/2022",
-        "extraGameProperties": {
-            "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
-        },
-        "xcloudUrl": "https://www.xbox.com/%s/play/games/let's-build-a-zoo/9P8N66DTG10T",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.63900.14084512162357210.0d6eea09-167f-4aad-97d7-d4d17f848799.2a1722e7-328d-4bb3-b556-0d4acae1567b?w=%i&h=%i",
-        "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.15530.14084512162357210.0d6eea09-167f-4aad-97d7-d4d17f848799.9a461717-eb83-4a42-875e-7c96139197b1?h=%i&format=jpg",
-        "storeUrl": "https://www.xbox.com/games/store/let's-build-a-zoo/9P8N66DTG10T"
-    },
-    {
-        "gameTitle": "Medieval Dynasty",
-        "gamePublisher": "Toplitz Productions",
-        "gameDeveloper": "Render Cube",
-        "gameGenres": [
-            "A\u00e7\u00e3o e aventura",
-            "RPG"
-        ],
-        "releaseDate": "06/10/2022",
-        "extraGameProperties": {
-            "isInGamePass": true,
-            "controllerSupport": false,
-            "touchControllerSupport": false
-        },
-        "xcloudUrl": "https://www.xbox.com/%s/play/games/medieval-dynasty/9PDDP6ML6XHF",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.26306.14156112272410024.03b91df3-d826-4d77-a692-6b75d9b18188.14e344a6-e6f9-43bd-8f8d-f6e965429119?w=%i&h=%i",
-        "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.63309.14156112272410024.03b91df3-d826-4d77-a692-6b75d9b18188.85b2f37e-0bd7-4de5-a925-bc86f2c59896?h=%i&format=jpg",
-        "storeUrl": "https://www.xbox.com/games/store/medieval-dynasty/9PDDP6ML6XHF"
-    },
-    {
-        "gameTitle": "Moonscars",
-        "gamePublisher": "Humble Games",
-        "gameDeveloper": "Black Mermaid",
+        "gameTitle": "LAPIN (Game Preview)",
+        "gamePublisher": "Studio Doodal",
+        "gameDeveloper": "Studio Doodal",
         "gameGenres": [
             "A\u00e7\u00e3o e aventura",
             "Plataforma"
         ],
-        "releaseDate": "27/09/2022",
+        "releaseDate": "16/11/2022",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
-        "xcloudUrl": "https://www.xbox.com/%s/play/games/moonscars/9P77VD8MGJX8",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.48607.14609228948314679.57b5d232-e029-48c3-a08c-a51885c8f604.a75be4f6-a08c-465f-8452-bf3c2ee5da75?w=%i&h=%i",
-        "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.16286.14609228948314679.57b5d232-e029-48c3-a08c-a51885c8f604.af5bedd3-16ab-4c9d-a23d-deda8b3b585f?h=%i&format=jpg",
-        "storeUrl": "https://www.xbox.com/games/store/moonscars/9P77VD8MGJX8"
+        "xcloudUrl": "https://www.xbox.com/%s/play/games/lapin-game-preview/9NBQHM0GM30N",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.4556.13578896031022031.669735bf-c2ac-401f-ac66-dd1b562de1d2.d81b23a1-64de-41f4-933a-308cd818b557?w=%i&format=jpg",
+        "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.825.13578896031022031.669735bf-c2ac-401f-ac66-dd1b562de1d2.e8c98327-b7df-4387-8979-749fdbcc2be7?h=%i&format=jpg",
+        "storeUrl": "https://www.xbox.com/games/store/lapin-game-preview/9NBQHM0GM30N"
     },
     {
-        "gameTitle": "Patrulha Canina: Grand Prix",
-        "gamePublisher": "Outright Games Ltd.",
-        "gameDeveloper": "3DClouds",
+        "gameTitle": "LEGO\u00ae Star Wars\u2122: A Saga Skywalker",
+        "gamePublisher": "Warner Bros. Games",
+        "gameDeveloper": "TT Games",
         "gameGenres": [
-            "Fam\u00edlia e crian\u00e7as",
             "A\u00e7\u00e3o e aventura"
         ],
-        "releaseDate": "29/09/2022",
+        "releaseDate": "22/07/2019",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
-        "xcloudUrl": "https://www.xbox.com/%s/play/games/paw-patrol-grand-prix/9MWBT3HFCZ3Z",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.30417.13842132658396836.fba80705-9bc9-45ad-84f9-621f75fe99ec.63412d4a-24e5-449a-9622-75435adb7a73?w=%i&h=%i",
-        "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.53527.13842132658396836.fba80705-9bc9-45ad-84f9-621f75fe99ec.a7d39a33-f2c3-408b-a88d-4ef40eb5c446?h=%i&format=jpg",
-        "storeUrl": "https://www.xbox.com/games/store/patrulha-canina-grand-prix/9MWBT3HFCZ3Z"
+        "xcloudUrl": "https://www.xbox.com/%s/play/games/lego-star-wars-the-skywalker-saga/BRMKDCZT0C4L",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.7489.69776162813131649.5a0614cf-d90a-4580-90d2-d09e65459d75.24c8420c-5d5f-45f7-b495-59335a7ab2fb?w=%i&format=jpg",
+        "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.58124.69776162813131649.c3b28bba-c81b-49e6-8333-6c1ce8e9222a.8225a765-6b22-437b-bda5-5a65531d716a?h=%i&format=jpg",
+        "storeUrl": "https://www.xbox.com/games/store/lego-star-wars-a-saga-skywalker/BRMKDCZT0C4L"
     },
     {
-        "gameTitle": "Prodeus",
-        "gamePublisher": "Humble Games",
-        "gameDeveloper": "Bounding Box Software Inc.",
+        "gameTitle": "NORCO",
+        "gamePublisher": "Raw Fury",
+        "gameDeveloper": "Geography of Robots",
+        "gameGenres": [
+            "A\u00e7\u00e3o e aventura"
+        ],
+        "releaseDate": "23/03/2022",
+        "extraGameProperties": {
+            "isInGamePass": true,
+            "controllerSupport": true,
+            "touchControllerSupport": false
+        },
+        "xcloudUrl": "https://www.xbox.com/%s/play/games/norco/9NZFZXDRZQLR",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.25342.14481237140487412.88b201c5-42cf-43cc-af65-86f48324703c.ffed0473-d7e2-4f24-9dc3-b665a6eae08a?w=%i&format=jpg",
+        "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.28816.14481237140487412.88b201c5-42cf-43cc-af65-86f48324703c.af71efde-62f6-4a00-8353-872b67548d33?h=%i&format=jpg",
+        "storeUrl": "https://www.xbox.com/games/store/norco/9NZFZXDRZQLR"
+    },
+    {
+        "gameTitle": "Potion Craft: Alchemist Simulator",
+        "gamePublisher": "tinyBuild",
+        "gameDeveloper": "niceplay games",
+        "gameGenres": [
+            "Desafios",
+            "Simula\u00e7\u00e3o"
+        ],
+        "releaseDate": "19/12/2021",
+        "extraGameProperties": {
+            "isInGamePass": true,
+            "controllerSupport": true,
+            "touchControllerSupport": false
+        },
+        "xcloudUrl": "https://www.xbox.com/%s/play/games/potion-craft-alchemist-simulator/9MW7WD7J3PPK",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.17503.13848482346226692.76b37d69-4a55-4077-ae36-a8f49e2ccf1c.8a22c7e1-e58b-4e64-aa00-5a039852fdd5?w=%i&format=jpg",
+        "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.15930.13848482346226692.76b37d69-4a55-4077-ae36-a8f49e2ccf1c.28213b1a-85fa-4728-9131-497e372e965c?h=%i&format=jpg",
+        "storeUrl": "https://www.xbox.com/games/store/potion-craft-alchemist-simulator/9MW7WD7J3PPK"
+    },
+    {
+        "gameTitle": "Rainbow Billy: The Curse of the Leviathan",
+        "gamePublisher": "Skybound Games",
+        "gameDeveloper": "ManaVoid Entertainment",
         "gameGenres": [
             "A\u00e7\u00e3o e aventura",
-            "Jogos de tiros"
+            "RPG"
         ],
-        "releaseDate": "23/06/2021",
+        "releaseDate": "05/10/2021",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
-        "xcloudUrl": "https://www.xbox.com/%s/play/games/prodeus/9MZRSLLWKWDV",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.13041.13864617007662897.01825ec5-fdc1-49fc-a5ac-f29f1860b3d2.b9a8b49a-0945-4ea8-a389-1cc6ba14ba50?w=%i&h=%i",
-        "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.9406.13864617007662897.01825ec5-fdc1-49fc-a5ac-f29f1860b3d2.4de0b1f4-bc29-45f6-9f06-cb0449d3d4d3?h=%i&format=jpg",
-        "storeUrl": "https://www.xbox.com/games/store/prodeus/9MZRSLLWKWDV"
+        "xcloudUrl": "https://www.xbox.com/%s/play/games/rainbow-billy-the-curse-of-the-leviathan/9PMGFL6KM0T2",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.29645.14293952320453711.7b0495b8-be6b-4fbc-9d4c-95bf880b7637.aee8335d-6c09-4147-bf12-78be5fd5ecb2?w=%i&format=jpg",
+        "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.14520.14293952320453711.7b0495b8-be6b-4fbc-9d4c-95bf880b7637.07a5a89a-6176-4c24-bed7-c0b61b4c42a9?h=%i&format=jpg",
+        "storeUrl": "https://www.xbox.com/games/store/rainbow-billy-the-curse-of-the-leviathan/9PMGFL6KM0T2"
     },
     {
-        "gameTitle": "Scorn",
-        "gamePublisher": "Kepler Interactive",
-        "gameDeveloper": "Ebb Software",
+        "gameTitle": "Soccer Story",
+        "gamePublisher": "No More Robots",
+        "gameDeveloper": "PanicBarn",
+        "gameGenres": [
+            "A\u00e7\u00e3o e aventura",
+            "Fam\u00edlia e crian\u00e7as"
+        ],
+        "releaseDate": "28/11/2022",
+        "extraGameProperties": {
+            "isInGamePass": true,
+            "controllerSupport": true,
+            "touchControllerSupport": false
+        },
+        "xcloudUrl": "https://www.xbox.com/%s/play/games/soccer-story/9PJ1045MHZJ0",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.16567.14225521066737419.4d59d91e-770c-4a84-9fda-21fa57c19bbc.a99bcfc5-804f-4e1f-8e14-e27ad70afbc4?w=%i&format=jpg",
+        "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.54220.14225521066737419.4d59d91e-770c-4a84-9fda-21fa57c19bbc.af62fb1e-8600-4163-b871-03b245cf84a8?h=%i&format=jpg",
+        "storeUrl": "https://www.xbox.com/games/store/soccer-story/9PJ1045MHZJ0"
+    },
+    {
+        "gameTitle": "The Elder Scrolls\u00ae Online",
+        "gamePublisher": "Bethesda Softworks",
+        "gameDeveloper": "ZeniMax Online Studios",
+        "gameGenres": [
+            "RPG"
+        ],
+        "releaseDate": "05/06/2017",
+        "extraGameProperties": {
+            "isInGamePass": true,
+            "controllerSupport": true,
+            "touchControllerSupport": false
+        },
+        "xcloudUrl": "https://www.xbox.com/%s/play/games/the-elder-scrolls-online/BRKX5CRMRTC2",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.5.69742768075920623.e6c8e1ee-e782-4002-bca6-916e5cd2f37c.c83904e1-a85d-4e2a-9d8c-63e0acacc011?w=%i&format=jpg",
+        "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.42994.69742768075920623.e6c8e1ee-e782-4002-bca6-916e5cd2f37c.72f4ca2d-e167-4637-aac3-c9c37eaec0b7?h=%i&format=jpg",
+        "storeUrl": "https://www.xbox.com/games/store/the-elder-scrolls-online/BRKX5CRMRTC2"
+    },
+    {
+        "gameTitle": "The Walking Dead: A Temporada Final - The Complete Season",
+        "gamePublisher": "Skybound Games",
+        "gameDeveloper": "Telltale Games",
         "gameGenres": [
             "A\u00e7\u00e3o e aventura"
         ],
-        "releaseDate": "14/10/2022",
+        "releaseDate": "13/08/2018",
         "extraGameProperties": {
             "isInGamePass": true,
-            "controllerSupport": false,
+            "controllerSupport": true,
             "touchControllerSupport": false
         },
-        "xcloudUrl": "https://www.xbox.com/%s/play/games/scorn/9NM3TNRPQXLR",
-        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.51381.13699799412731780.9f7b812e-456c-430e-8cec-380f1ca9e4a2.dd9f4725-f6e0-4fe4-9484-9d5f22682786?w=%i&h=%i",
-        "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.16661.13699799412731780.1afb5b8c-d3cf-40b3-aa5e-f5e01adefd6c.71e32c0e-4c10-4a4b-a813-3478373b1769?h=%i&format=jpg",
-        "storeUrl": "https://www.xbox.com/games/store/scorn/9NM3TNRPQXLR"
+        "xcloudUrl": "https://www.xbox.com/%s/play/games/the-walking-dead-the-final-season---the-complete-s/C0VQBXFNZ1Q0",
+        "tileGameImageUrl": "https://store-images.s-microsoft.com/image/apps.63360.65079731096933175.a08cf79d-9c48-4fcd-90eb-63df0c6a136c.4771e790-cd77-4316-a708-a82c7f28b996?w=%i&format=jpg",
+        "gameImageUrl": "https://store-images.s-microsoft.com/image/apps.9967.65079731096933175.a08cf79d-9c48-4fcd-90eb-63df0c6a136c.694bcbcd-e366-4c1a-9ba1-96861c66d173?h=%i&format=jpg",
+        "storeUrl": "https://www.xbox.com/games/store/the-walking-dead-a-temporada-final---the-complete-/C0VQBXFNZ1Q0"
     }
 ]


### PR DESCRIPTION
Migrate some of the code that was made on the hook implementation, since the hooks will be no longer implemented.

Closes #47 

## Main changes
- Tiles can't have more than one size at ```TileRow```.
- Fix ```TileTitleBar``` and ```TileBadges```.
- Fix samll bugs at UI.
- Sync ```xcloud_game_picker``` with the XCloud site.